### PR TITLE
feat: add toast notifications for background operations

### DIFF
--- a/frontend/src/app/[locale]/admin/disputes/page.tsx
+++ b/frontend/src/app/[locale]/admin/disputes/page.tsx
@@ -125,6 +125,8 @@ export default function AdminDisputesPage() {
         queryClient.invalidateQueries({ queryKey: queryKeys.adminDisputes.all() });
       }
     },
+    showToasts: true,
+    toastPrefix: "Admin events",
   });
 
   if (isChecking || !isAdmin) {

--- a/frontend/src/app/[locale]/lend/LendPageClient.tsx
+++ b/frontend/src/app/[locale]/lend/LendPageClient.tsx
@@ -72,6 +72,8 @@ export function LendPageClient() {
       }
     },
     onFallbackPoll: () => invalidatePoolStats(),
+    showToasts: true,
+    toastPrefix: "Pool updates",
   });
 
   const depositPrecisionError = getPrecisionError(depositAmount, "USDC");

--- a/frontend/src/app/components/providers/WalletProvider.tsx
+++ b/frontend/src/app/components/providers/WalletProvider.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from "react";
 import type { TokenBalance, WalletNetwork, WalletStatus } from "../../stores/useWalletStore";
 import { useWalletStore } from "../../stores/useWalletStore";
+import { useWalletToasts } from "../../hooks/useWalletToasts";
 
 type FreighterApi = typeof import("@stellar/freighter-api");
 
@@ -270,6 +271,9 @@ export function WalletProvider({ children }: WalletProviderProps) {
     if (!shouldAutoReconnect && !address) return;
     await syncWallet(false);
   }
+
+  // Toast notifications for wallet state changes
+  useWalletToasts();
 
   // Initial check and Auto-reconnect
   useEffect(() => {

--- a/frontend/src/app/components/remittance/RemittanceForm.tsx
+++ b/frontend/src/app/components/remittance/RemittanceForm.tsx
@@ -11,7 +11,6 @@ import { isValidStellarAddress } from "../../utils/stellar";
 import { AlertCircle, Send, Loader } from "lucide-react";
 import { useCreateRemittance } from "../../hooks/useApi";
 import { truncateDecimals, getAssetPrecision } from "../../utils/precision";
-import { toast } from "sonner";
 import {
   buildAmountHelperText,
   getPrecisionError,
@@ -20,6 +19,7 @@ import {
   formatAmountOnBlur,
   getAssetDecimals,
 } from "../../utils/amount";
+import { useContractToast } from "../../hooks/useContractToast";
 
 interface RemittanceFormProps {
   onSuccess?: () => void;
@@ -37,6 +37,7 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
   const decimals = getAssetDecimals(token);
   const precisionError = getPrecisionError(amount, token);
   const helperText = buildAmountHelperText(amount, token, decimals);
+  const toast = useContractToast();
 
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};
@@ -97,9 +98,7 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
 
   const handleReviewTransaction = async () => {
     if (!validateForm()) {
-      toast.error("Validation Error", {
-        description: "Please fix the errors in the form",
-      });
+      toast.error("Validation Error", "Please fix the errors in the form");
       return;
     }
 
@@ -126,9 +125,7 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
         memo: memo || undefined,
       });
 
-      toast.success("Success!", {
-        description: "Remittance sent successfully",
-      });
+      toast.success("Success!", "Remittance sent successfully");
 
       // Reset form
       setRecipientAddress("");
@@ -139,9 +136,7 @@ export function RemittanceForm({ onSuccess }: RemittanceFormProps) {
       onSuccess?.();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Failed to send remittance";
-      toast.error("Error", {
-        description: errorMessage,
-      });
+      toast.error("Error", errorMessage);
     }
   };
 

--- a/frontend/src/app/hooks/useLoanStream.ts
+++ b/frontend/src/app/hooks/useLoanStream.ts
@@ -64,5 +64,7 @@ export function useLoanStream(loanId: string | undefined): RealtimeStatus {
       invalidateLoanQueries();
     },
     onFallbackPoll: invalidateLoanQueries,
+    showToasts: true,
+    toastPrefix: "Loan updates",
   });
 }

--- a/frontend/src/app/hooks/useSSE.ts
+++ b/frontend/src/app/hooks/useSSE.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useUserStore } from "../stores/useUserStore";
+import { useToastStore } from "../stores/useToastStore";
 
 export type SSEStatus = "connecting" | "connected" | "disconnected";
 export type RealtimeStatus = SSEStatus | "polling";
@@ -19,6 +20,10 @@ interface UseSSEOptions<T> {
   onFallbackPoll?: () => void | Promise<void>;
   /** Polling interval in milliseconds when in fallback mode. Default: 30000 (30s) */
   pollingInterval?: number;
+  /** Show toast notifications for connection status changes */
+  showToasts?: boolean;
+  /** Custom message prefix for toast notifications */
+  toastPrefix?: string;
 }
 
 /**
@@ -33,6 +38,8 @@ export function useSSE<T = unknown>({
   onError,
   onFallbackPoll,
   pollingInterval = 30_000,
+  showToasts = false,
+  toastPrefix = "Live updates",
 }: UseSSEOptions<T>): RealtimeStatus {
   const [status, setStatus] = useState<RealtimeStatus>("connecting");
   const token = useUserStore((s) => s.authToken);
@@ -42,6 +49,19 @@ export function useSSE<T = unknown>({
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const reconnectAttempts = useRef(0);
   const maxReconnectAttempts = 3;
+  const previousStatusRef = useRef<RealtimeStatus>("connecting");
+  const toastIdRef = useRef<string | null>(null);
+  const { addToast, updateToast, dismissToast } = useToastStore();
+
+  const showToast = (type: "info" | "success" | "error" | "warning", title: string, description?: string, options?: { duration?: number; action?: { label: string; onClick: () => void } }) => {
+    if (!showToasts) return;
+    return addToast({ type, title, description, ...options });
+  };
+
+  const updateToastMessage = (toastId: string | null, type: "info" | "success" | "error" | "warning", title: string, description?: string, options?: { duration?: number; action?: { label: string; onClick: () => void } }) => {
+    if (!showToasts || !toastId) return;
+    updateToast(toastId, { type, title, description, ...options });
+  };
 
   const onMessageRef = useRef(onMessage);
   onMessageRef.current = onMessage;
@@ -73,6 +93,8 @@ export function useSSE<T = unknown>({
       }
 
       setStatus("polling");
+      // Show polling toast
+      toastIdRef.current = showToast("info", `${toastPrefix}: Using polling fallback`, "Real-time updates temporarily unavailable. Refreshing every 30 seconds.", { duration: 0 });
       void onFallbackPollRef.current();
       pollingIntervalRef.current = setInterval(() => {
         void onFallbackPollRef.current?.();
@@ -87,6 +109,10 @@ export function useSSE<T = unknown>({
       }
 
       setStatus("connecting");
+      // Show connecting toast (only if not already connecting)
+      if (previousStatusRef.current !== "connecting") {
+        toastIdRef.current = showToast("info", `${toastPrefix}: Connecting...`, "Establishing real-time connection");
+      }
       const controller = new AbortController();
       abortControllerRef.current = controller;
 
@@ -117,6 +143,12 @@ export function useSSE<T = unknown>({
         retryDelay.current = 1_000;
         reconnectAttempts.current = 0;
         onOpenRef.current?.();
+
+        // Show connected toast
+        if (previousStatusRef.current !== "connected") {
+          updateToastMessage(toastIdRef.current, "success", `${toastPrefix}: Connected`, "Real-time updates are active", { duration: 3000 });
+          toastIdRef.current = null;
+        }
 
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
@@ -161,10 +193,16 @@ export function useSSE<T = unknown>({
         if (!cancelled) {
           const delay = Math.min(retryDelay.current, 5_000);
           retryDelay.current = Math.min(delay * 2, 30_000);
+          // Show reconnecting toast
+          updateToastMessage(toastIdRef.current, "warning", `${toastPrefix}: Reconnecting...`, `Attempt ${reconnectAttempts.current}/${maxReconnectAttempts}. Retrying in ${delay / 1000}s...`, { duration: 0 });
           timeoutRef.current = setTimeout(connect, delay);
         }
       }
     }
+
+    // Track status changes for toast notifications
+    const prevStatus = previousStatusRef.current;
+    previousStatusRef.current = status;
 
     connect();
 
@@ -177,8 +215,12 @@ export function useSSE<T = unknown>({
         clearTimeout(timeoutRef.current);
       }
       stopPolling();
+      // Clean up toast on unmount if still showing
+      if (toastIdRef.current) {
+        dismissToast(toastIdRef.current);
+      }
     };
-  }, [url, token, pollingInterval]);
+  }, [url, token, pollingInterval, showToasts, toastPrefix]);
 
   return status;
 }

--- a/frontend/src/app/hooks/useWalletToasts.ts
+++ b/frontend/src/app/hooks/useWalletToasts.ts
@@ -1,0 +1,146 @@
+"use client";
+
+import React, { useEffect, useRef } from "react";
+import { useWalletStore } from "../stores/useWalletStore";
+import { useToastStore } from "../stores/useToastStore";
+
+/**
+ * Hook that listens to wallet store changes and shows toast notifications.
+ * Provides user feedback for wallet connection state changes, network switches, etc.
+ */
+export function useWalletToasts() {
+  const status = useWalletStore((state) => state.status);
+  const address = useWalletStore((state) => state.address);
+  const network = useWalletStore((state) => state.network);
+  const error = useWalletStore((state) => state.error);
+  const shouldAutoReconnect = useWalletStore((state) => state.shouldAutoReconnect);
+
+  const { addToast, dismissToast } = useToastStore();
+
+  // Track previous values to detect changes
+  const prevStatusRef = useRef(status);
+  const prevAddressRef = useRef(address);
+  const prevNetworkRef = useRef(network);
+  const toastIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    // Status changes
+    if (prevStatusRef.current !== status) {
+      const prevStatus = prevStatusRef.current;
+      prevStatusRef.current = status;
+
+      switch (status) {
+        case "connecting":
+          toastIdRef.current = addToast({
+            type: "info",
+            title: "Connecting wallet...",
+            description: "Please approve the connection in Freighter",
+            duration: 0, // Persistent until updated
+          });
+          break;
+
+        case "connected":
+          // Dismiss connecting toast
+          if (toastIdRef.current) {
+            dismissToast(toastIdRef.current);
+            toastIdRef.current = null;
+          }
+          if (prevStatus === "connecting" || prevStatus === "disconnected") {
+            addToast({
+              type: "success",
+              title: "Wallet connected",
+              description: address ? `Connected as ${address.slice(0, 6)}...${address.slice(-4)}` : "Ready to use",
+              duration: 4000,
+            });
+          } else if (prevStatus === "error") {
+            addToast({
+              type: "success",
+              title: "Wallet reconnected",
+              description: "Connection restored successfully",
+              duration: 4000,
+            });
+          }
+          break;
+
+        case "disconnected":
+          // Dismiss any pending toast
+          if (toastIdRef.current) {
+            dismissToast(toastIdRef.current);
+            toastIdRef.current = null;
+          }
+          if (prevStatus === "connected") {
+            addToast({
+              type: "info",
+              title: "Wallet disconnected",
+              description: "Reconnect anytime to continue borrowing and lending",
+              duration: 4000,
+            });
+          }
+          break;
+
+        case "error":
+          if (toastIdRef.current) {
+            dismissToast(toastIdRef.current);
+            toastIdRef.current = null;
+          }
+          if (error) {
+            addToast({
+              type: "error",
+              title: "Wallet error",
+              description: error,
+              duration: 10000,
+            });
+          }
+          break;
+      }
+    }
+  }, [status, address, error, addToast, dismissToast]);
+
+  // Address changes (account switch in wallet)
+  useEffect(() => {
+    if (prevAddressRef.current !== address && address && prevAddressRef.current) {
+      prevAddressRef.current = address;
+      addToast({
+        type: "info",
+        title: "Account changed",
+        description: `Switched to ${address.slice(0, 6)}...${address.slice(-4)}`,
+        duration: 4000,
+      });
+    } else if (address) {
+      prevAddressRef.current = address;
+    }
+  }, [address, addToast]);
+
+  // Network changes
+  useEffect(() => {
+    if (prevNetworkRef.current !== network && network && prevNetworkRef.current) {
+      const prevNetwork = prevNetworkRef.current;
+      prevNetworkRef.current = network;
+
+      if (prevNetwork?.name !== network.name) {
+        addToast({
+          type: network.isSupported ? "info" : "warning",
+          title: "Network changed",
+          description: network.isSupported
+            ? `Switched to ${network.name}`
+            : `Unsupported network: ${network.name}. Switch to PUBLIC, TESTNET, FUTURENET, or STANDALONE.`,
+          duration: network.isSupported ? 4000 : 10000,
+        });
+      }
+    } else if (network) {
+      prevNetworkRef.current = network;
+    }
+  }, [network, addToast]);
+
+  // Auto-reconnect toast
+  useEffect(() => {
+    if (shouldAutoReconnect && status === "disconnected" && address) {
+      addToast({
+        type: "info",
+        title: "Auto-reconnecting wallet...",
+        description: "Restoring your previous session",
+        duration: 3000,
+      });
+    }
+  }, [shouldAutoReconnect, status, address, addToast]);
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive toast notifications for background operations to address the issue where users receive no feedback for background operations.

## Changes

- **New hook:**  - Listens to wallet store changes and shows toast notifications for:
  - Wallet connection (connecting, connected, disconnected, error)
  - Account switching in Freighter
  - Network changes (with warning for unsupported networks)
  - Auto-reconnect attempts

- **Enhanced  hook** with  and  options:
  - Shows "Connecting..." toast when establishing connection
  - Shows "Connected" toast when real-time connection established
  - Shows "Reconnecting..." toast with attempt count during retries
  - Shows "Using polling fallback" toast when SSE fails and falls back to polling
  - Shows "Connected" toast when reconnection succeeds

- **Enabled toasts in components:**
  -  - Loan updates (connected, polling, reconnecting)
  -  - Pool updates (connected, polling, reconnecting)
  -  - Admin events (connected, polling, reconnecting)

- **Consistency fix:** Migrated  from using  directly to  for consistent toast styling and behavior

- **Integrated wallet toasts** into  for automatic toast notifications on wallet state changes

## Issue References

Closes #155
Closes #156
Closes #157
Closes #158