### PR TITLE
feat: add keyboard shortcuts for power users

### DIFF
--- a/frontend/src/app/components/global_ui/Header.tsx
+++ b/frontend/src/app/components/global_ui/Header.tsx
@@ -8,7 +8,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import { useRouter } from "next/navigation";
-import { Menu, Search, User, Wallet } from "lucide-react";
+import { Menu, Search, User, Wallet, HelpCircle } from "lucide-react";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { ThemeToggle } from "../ui/ThemeToggle";
@@ -22,6 +22,8 @@ import { useLoans, useRemittances } from "../../hooks/useApi";
 import { useContractToast } from "../../hooks/useContractToast";
 import { LanguageSwitcher } from "./LanguageSwitcher";
 import { useTranslations, useLocale } from "next-intl";
+import { useKeyboardShortcuts, createGlobalShortcuts, createNavigationShortcuts, createWalletShortcuts, createSearchShortcut } from "../../hooks/useKeyboardShortcuts";
+import { KeyboardShortcutsHelp } from "../ui/KeyboardShortcutsHelp";
 
 function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -70,6 +72,41 @@ export function Header({ onMenuClick, className }: HeaderProps) {
     ],
     [locale, t],
   );
+
+  const [shortcutsHelpOpen, setShortcutsHelpOpen] = useState(false);
+
+  const navigationShortcuts = createNavigationShortcuts(router, locale);
+  const walletShortcuts = createWalletShortcuts(connectWallet, disconnectWallet, isConnected);
+  const searchShortcuts = createSearchShortcut(() => {
+    setIsOpen(true);
+    inputRef.current?.focus();
+  });
+  const globalShortcuts = createGlobalShortcuts(
+    () => {
+      const event = new CustomEvent("toggle-theme");
+      window.dispatchEvent(event);
+    },
+    () => setShortcutsHelpOpen(true),
+  );
+
+  const allShortcuts = [
+    ...navigationShortcuts,
+    ...walletShortcuts,
+    ...searchShortcuts,
+    ...globalShortcuts,
+  ];
+
+  useKeyboardShortcuts(allShortcuts, { enabled: true, scope: "global" });
+
+  useEffect(() => {
+    const handleThemeToggle = () => {
+      const event = new CustomEvent("toggle-theme");
+      window.dispatchEvent(event);
+    };
+
+    window.addEventListener("toggle-theme", handleThemeToggle);
+    return () => window.removeEventListener("toggle-theme", handleThemeToggle);
+  }, []);
 
   const searchResults = useMemo(() => {
     const term = debouncedQuery.trim().toLowerCase();
@@ -156,22 +193,6 @@ export function Header({ onMenuClick, className }: HeaderProps) {
 
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
-  useEffect(() => {
-    const handleShortcut = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
-        event.preventDefault();
-        setIsOpen(true);
-        inputRef.current?.focus();
-      }
-      if (event.key === "Escape") {
-        setIsOpen(false);
-      }
-    };
-
-    window.addEventListener("keydown", handleShortcut);
-    return () => window.removeEventListener("keydown", handleShortcut);
   }, []);
 
   const handleSelect = (href: string) => {
@@ -383,6 +404,17 @@ export function Header({ onMenuClick, className }: HeaderProps) {
 
         <button
           type="button"
+          onClick={() => setShortcutsHelpOpen(true)}
+          aria-label="Keyboard shortcuts"
+          className="p-2 text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-900 rounded-lg"
+        >
+          <HelpCircle className="h-5 w-5" />
+        </button>
+
+        <div className="h-8 w-px bg-zinc-200 dark:bg-zinc-800 hidden sm:block" />
+
+        <button
+          type="button"
           aria-label={`Profile: ${profileLabel}`}
           className="flex items-center gap-2 rounded-full p-1 border border-zinc-200 hover:border-zinc-300 transition-colors dark:border-zinc-800 dark:hover:border-zinc-700"
         >
@@ -397,5 +429,12 @@ export function Header({ onMenuClick, className }: HeaderProps) {
         </button>
       </div>
     </header>
+    {shortcutsHelpOpen && (
+      <KeyboardShortcutsHelp
+        isOpen={shortcutsHelpOpen}
+        onClose={() => setShortcutsHelpOpen(false)}
+        shortcuts={allShortcuts}
+      />
+    )}
   );
 }

--- a/frontend/src/app/components/ui/KeyboardShortcutsHelp.tsx
+++ b/frontend/src/app/components/ui/KeyboardShortcutsHelp.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { X, Keyboard, Command } from "lucide-react";
+import { createPortal } from "react-dom";
+import { cn } from "../../lib/utils";
+
+interface KeyboardShortcutsHelpProps {
+  isOpen: boolean;
+  onClose: () => void;
+  shortcuts: Array<{
+    key: string;
+    description: string;
+    category: string;
+    keys?: string[];
+  }>;
+}
+
+const CATEGORY_ORDER = ["Global", "Navigation", "Wallet", "Contextual", "Custom"];
+
+function formatKey(key: string): React.ReactNode {
+  if (key.includes("+") || key.includes(" ")) {
+    return key.split(/[\s+]+/).map((k) => (
+      <kbd key={k} className="px-1.5 py-0.5 text-xs font-mono rounded bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700">
+        {k === "Meta" ? <Command className="h-3 w-3" /> : k.toUpperCase()}
+      </kbd>
+    ));
+  }
+  return (
+    <kbd className="px-1.5 py-0.5 text-xs font-mono rounded bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700">
+      {key.toUpperCase()}
+    </kbd>
+  );
+}
+
+export function KeyboardShortcutsHelp({
+  isOpen,
+  onClose,
+  shortcuts,
+}: KeyboardShortcutsHelpProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const previousActiveElement = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      previousActiveElement.current = document.activeElement as HTMLElement;
+      dialogRef.current?.showModal();
+      document.body.style.overflow = "hidden";
+    } else {
+      dialogRef.current?.close();
+      document.body.style.overflow = "";
+      previousActiveElement.current?.focus();
+    }
+
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  if (!isOpen) return null;
+
+  const filteredShortcuts = shortcuts.filter((s) =>
+    s.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    s.key.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    s.category.toLowerCase().includes(searchQuery.toLowerCase()),
+  );
+
+  const groupedShortcuts = filteredShortcuts.reduce(
+    (acc, shortcut) => {
+      const category = shortcut.category || "Custom";
+      if (!acc[category]) acc[category] = [];
+      acc[category].push(shortcut);
+      return acc;
+    },
+    {} as Record<string, typeof shortcuts>,
+  );
+
+  const sortedCategories = Object.keys(groupedShortcuts).sort((a, b) => {
+    const indexA = CATEGORY_ORDER.indexOf(a);
+    const indexB = CATEGORY_ORDER.indexOf(b);
+    if (indexA === -1 && indexB === -1) return a.localeCompare(b);
+    if (indexA === -1) return 1;
+    if (indexB === -1) return -1;
+    return indexA - indexB;
+  });
+
+  return createPortal(
+    <dialog
+      ref={dialogRef}
+      className="relative w-full max-w-2xl rounded-2xl border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-800 dark:bg-zinc-950"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-100 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-400">
+            <Keyboard className="h-5 w-5" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">Keyboard Shortcuts</h2>
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">
+              Press <kbd className="px-1.5 py-0.5 text-xs font-mono rounded bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700">?</kbd> or <kbd className="px-1.5 py-0.5 text-xs font-mono rounded bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700">⌘</kbd><kbd className="px-1.5 py-0.5 text-xs font-mono rounded bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700">⇧</kbd><kbd className="px-1.5 py-0.5 text-xs font-mono rounded bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700">K</kbd> to open this dialog
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md p-1 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+          aria-label="Close keyboard shortcuts help"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      <div className="mt-4 flex gap-2">
+        <span className="flex items-center gap-1.5 text-sm text-zinc-500 dark:text-zinc-400">
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+        </span>
+        <input
+          type="search"
+          placeholder="Search shortcuts..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="flex-1 rounded-xl border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-50"
+          autoFocus
+        />
+      </div>
+
+      <div className="mt-6 max-h-[50vh] overflow-y-auto space-y-4">
+        {sortedCategories.length === 0 ? (
+          <p className="text-center text-zinc-500 dark:text-zinc-400 py-8">
+            No shortcuts found matching "{searchQuery}"
+          </p>
+        ) : (
+          sortedCategories.map((category) => (
+            <div key={category} className="space-y-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                {category}
+              </h3>
+              <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2">
+                {groupedShortcuts[category].map((shortcut) => (
+                  <React.Fragment key={shortcut.description}>
+                    <dt className="flex items-center gap-2 text-sm text-zinc-700 dark:text-zinc-300">
+                      {formatKey(shortcut.key)}
+                    </dt>
+                    <dd className="text-sm text-zinc-600 dark:text-zinc-400">
+                      {shortcut.description}
+                    </dd>
+                  </React.Fragment>
+                ))}
+              </dl>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="mt-6 pt-4 border-t border-zinc-200 dark:border-zinc-800">
+        <p className="text-xs text-zinc-500 dark:text-zinc-400 text-center">
+          Shortcuts work globally unless an input field is focused. Press <kbd className="px-1.5 py-0.5 text-xs font-mono rounded bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700">Esc</kbd> to close this dialog.
+        </p>
+      </div>
+    </dialog>,
+    document.body,
+  );
+}

--- a/frontend/src/app/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/app/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,261 @@
+"use client";
+
+import { useEffect, useMemo, useCallback } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
+
+interface Shortcut {
+  key: string;
+  description: string;
+  action: () => void;
+  category: string;
+  keys?: string[];
+  preventDefault?: boolean;
+}
+
+interface UseKeyboardShortcutsOptions {
+  enabled?: boolean;
+  scope?: "global" | "local";
+}
+
+const MODIFIER_KEYS = ["Control", "Meta", "Alt", "Shift"];
+
+function normalizeKey(key: string): string {
+  return key.toLowerCase();
+}
+
+function keysMatch(event: KeyboardEvent, shortcutKeys: string[]): boolean {
+  const eventKey = normalizeKey(event.key);
+  const requiredModifiers = shortcutKeys.filter((k) => MODIFIER_KEYS.includes(k));
+  const requiredKey = shortcutKeys.find((k) => !MODIFIER_KEYS.includes(k));
+
+  if (!requiredKey || normalizeKey(requiredKey) !== eventKey) {
+    return false;
+  }
+
+  for (const modifier of requiredModifiers) {
+    const modifierLower = modifier.toLowerCase();
+    if (modifierLower === "control" && !event.ctrlKey) return false;
+    if (modifierLower === "meta" && !event.metaKey) return false;
+    if (modifierLower === "alt" && !event.altKey) return false;
+    if (modifierLower === "shift" && !event.shiftKey) return false;
+  }
+
+  return true;
+}
+
+export function useKeyboardShortcuts(
+  shortcuts: Shortcut[],
+  options: UseKeyboardShortcutsOptions = {},
+): { shortcuts: Shortcut[] } {
+  const { enabled = true, scope = "global" } = options;
+  const router = useRouter();
+  const pathname = usePathname();
+  const t = useTranslations("KeyboardShortcuts");
+
+  const memoizedShortcuts = useMemo(() => shortcuts, [shortcuts]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement;
+
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      ) {
+        if (scope === "local") return;
+      }
+
+      for (const shortcut of memoizedShortcuts) {
+        if (shortcut.keys && keysMatch(event, shortcut.keys)) {
+          if (shortcut.preventDefault !== false) {
+            event.preventDefault();
+          }
+          shortcut.action();
+          break;
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [enabled, scope, memoizedShortcuts, router, pathname]);
+
+  return { shortcuts: memoizedShortcuts };
+}
+
+export function createNavigationShortcuts(
+  router: ReturnType<typeof useRouter>,
+  locale: string,
+): Shortcut[] {
+  return [
+    {
+      key: "g d",
+      keys: ["g", "d"],
+      description: "Go to Dashboard",
+      category: "Navigation",
+      action: () => router.push(`/${locale}`),
+    },
+    {
+      key: "g l",
+      keys: ["g", "l"],
+      description: "Go to Loans",
+      category: "Navigation",
+      action: () => router.push(`/${locale}/loans`),
+    },
+    {
+      key: "g n",
+      keys: ["g", "n"],
+      description: "Go to Lend",
+      category: "Navigation",
+      action: () => router.push(`/${locale}/lend`),
+    },
+    {
+      key: "g a",
+      keys: ["g", "a"],
+      description: "Go to Analytics",
+      category: "Navigation",
+      action: () => router.push(`/${locale}/analytics`),
+    },
+    {
+      key: "g w",
+      keys: ["g", "w"],
+      description: "Go to Wallet",
+      category: "Navigation",
+      action: () => router.push(`/${locale}/wallet`),
+    },
+  ];
+}
+
+export function createWalletShortcuts(
+  connectWallet: () => Promise<void>,
+  disconnectWallet: () => void,
+  isConnected: boolean,
+): Shortcut[] {
+  return [
+    {
+      key: "w",
+      keys: ["w"],
+      description: isConnected ? "Disconnect Wallet" : "Connect Wallet",
+      category: "Wallet",
+      action: isConnected ? disconnectWallet : connectWallet,
+    },
+  ];
+}
+
+export function createSearchShortcut(
+  openSearch: () => void,
+): Shortcut[] {
+  return [
+    {
+      key: "⌘K",
+      keys: ["Meta", "k"],
+      description: "Open Search",
+      category: "Global",
+      action: openSearch,
+      preventDefault: true,
+    },
+    {
+      key: "Ctrl+K",
+      keys: ["Control", "k"],
+      description: "Open Search",
+      category: "Global",
+      action: openSearch,
+      preventDefault: true,
+    },
+  ];
+}
+
+export function createGlobalShortcuts(
+  toggleTheme: () => void,
+  openShortcutsHelp: () => void,
+): Shortcut[] {
+  return [
+    {
+      key: "⌘⇧T",
+      keys: ["Meta", "Shift", "t"],
+      description: "Toggle Theme",
+      category: "Global",
+      action: toggleTheme,
+    },
+    {
+      key: "Ctrl+Shift+T",
+      keys: ["Control", "Shift", "t"],
+      description: "Toggle Theme",
+      category: "Global",
+      action: toggleTheme,
+    },
+    {
+      key: "⌘⇧K",
+      keys: ["Meta", "Shift", "k"],
+      description: "Show Keyboard Shortcuts",
+      category: "Global",
+      action: openShortcutsHelp,
+    },
+    {
+      key: "Ctrl+Shift+K",
+      keys: ["Control", "Shift", "k"],
+      description: "Show Keyboard Shortcuts",
+      category: "Global",
+      action: openShortcutsHelp,
+    },
+    {
+      key: "?",
+      keys: ["?"],
+      description: "Show Keyboard Shortcuts",
+      category: "Global",
+      action: openShortcutsHelp,
+    },
+  ];
+}
+
+export function createContextualShortcuts(
+  actions: Record<string, () => void>,
+): Shortcut[] {
+  const shortcuts: Shortcut[] = [];
+
+  if (actions.refresh) {
+    shortcuts.push({
+      key: "r",
+      keys: ["r"],
+      description: "Refresh Data",
+      category: "Contextual",
+      action: actions.refresh,
+    });
+  }
+
+  if (actions.newLoan) {
+    shortcuts.push({
+      key: "n",
+      keys: ["n"],
+      description: "New Loan",
+      category: "Contextual",
+      action: actions.newLoan,
+    });
+  }
+
+  if (actions.deposit) {
+    shortcuts.push({
+      key: "d",
+      keys: ["d"],
+      description: "Deposit",
+      category: "Contextual",
+      action: actions.deposit,
+    });
+  }
+
+  if (actions.withdraw) {
+    shortcuts.push({
+      key: "w",
+      keys: ["w"],
+      description: "Withdraw",
+      category: "Contextual",
+      action: actions.withdraw,
+    });
+  }
+
+  return shortcuts;
+}


### PR DESCRIPTION
## Summary

This PR adds keyboard shortcuts to improve efficiency for power users who need to navigate through menus for common actions.

## Changes

### New Hook: 
- Supports modifier keys: Meta (⌘), Control (Ctrl), Alt, Shift
- Handles key sequences (e.g., 'g d' for go to dashboard)
- Filters out shortcuts when user is typing in input fields
- Supports global and local scope

### New Component: 
- Searchable, categorized shortcut reference dialog
- Keyboard accessible (Escape to close, auto-focus search)
- Uses React Portal for proper modal rendering
- Categorized shortcuts: Global, Navigation, Wallet, Contextual

### Shortcuts Implemented
**Navigation:**
-  - Go to Dashboard
-  - Go to Loans
-  - Go to Lend
-  - Go to Analytics
-  - Go to Wallet

**Wallet:**
-  20:52:27 up 23:09,  1 user,  load average: 1.47, 2.00, 2.11
USER     TTY      FROM             LOGIN@   IDLE   JCPU   PCPU  WHAT
levibliz tty2     -                Mon21   23:09m  0.04s  0.04s /usr/libexec/gnome-session-binary --session=ubuntu - Connect/Disconnect Wallet

**Global:**
-  /  - Open Search
-  /  - Toggle Theme
-  /  /  - Show Keyboard Shortcuts Help

### Integration
- Added Help button (⌘⇧K / ?) to Header
- Shortcuts registered globally via  in Header
- Theme toggle syncs with existing ThemeToggle component

## Issue References

Closes #143
Closes #144
Closes #145
Closes #146