### PR TITLE
fix: clear client state and cancel pending requests on wallet disconnect

### DIFF
--- a/frontend/src/app/components/providers/WalletProvider.tsx
+++ b/frontend/src/app/components/providers/WalletProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import type { TokenBalance, WalletNetwork, WalletStatus } from "../../stores/useWalletStore";
 import { useWalletStore } from "../../stores/useWalletStore";
 
@@ -109,10 +110,13 @@ async function loadFreighterApi(): Promise<FreighterApi> {
 }
 
 export function WalletProvider({ children }: WalletProviderProps) {
+  const queryClient = useQueryClient();
   const address = useWalletStore((state) => state.address);
   const shouldAutoReconnect = useWalletStore((state) => state.shouldAutoReconnect);
   const setConnected = useWalletStore((state) => state.setConnected);
   const disconnect = useWalletStore((state) => state.disconnect);
+  const disconnectAndCleanup = useWalletStore((state) => state.disconnectAndCleanup);
+  const setQueryClient = useWalletStore((state) => state.setQueryClient);
   const setBalances = useWalletStore((state) => state.setBalances);
   const setNetwork = useWalletStore((state) => state.setNetwork);
   const setStatus = useWalletStore((state) => state.setStatus);
@@ -120,6 +124,11 @@ export function WalletProvider({ children }: WalletProviderProps) {
   const setLoadingBalances = useWalletStore((state) => state.setLoadingBalances);
   const [isFreighterAvailable, setIsFreighterAvailable] = useState(false);
   const syncRef = useRef<Promise<void> | null>(null);
+
+  // Set query client for disconnect cleanup
+  useEffect(() => {
+    setQueryClient(queryClient);
+  }, [queryClient, setQueryClient]);
 
   async function refreshBalances(nextAddress: string, horizonUrl: string, status: WalletStatus) {
     setLoadingBalances(true);
@@ -232,7 +241,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
   }
 
   function disconnectWallet() {
-    disconnect();
+    disconnectAndCleanup();
   }
 
   const NETWORK_PASSPHRASES: Record<string, string> = {
@@ -309,7 +318,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
       if (typeof api.watchAddress === "function") {
         unwatchAddress = api.watchAddress((newAddress: string) => {
           if (!newAddress && address) {
-            disconnect();
+            disconnectAndCleanup();
           } else if (newAddress && newAddress !== address) {
             void refreshWallet();
           }

--- a/frontend/src/app/stores/useWalletStore.ts
+++ b/frontend/src/app/stores/useWalletStore.ts
@@ -16,6 +16,7 @@
 
 import { create } from "zustand";
 import { createJSONStorage, devtools, persist } from "zustand/middleware";
+import type { QueryClient } from "@tanstack/react-query";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -51,6 +52,8 @@ interface WalletState {
   error: string | null;
   /** Whether the app should try to restore the wallet on refresh */
   shouldAutoReconnect: boolean;
+  /** Query client for cancelling pending requests on disconnect */
+  queryClient: QueryClient | null;
 }
 
 interface WalletActions {
@@ -58,6 +61,10 @@ interface WalletActions {
   setConnected: (address: string, network: WalletNetwork) => void;
   /** Call on disconnect or user-initiated Sign Out with wallet */
   disconnect: () => void;
+  /** Enhanced disconnect that also cancels pending queries and clears cache */
+  disconnectAndCleanup: () => void;
+  /** Set the query client for cancelling pending requests */
+  setQueryClient: (client: QueryClient) => void;
   /** Update balances after fetching from the chain */
   setBalances: (balances: TokenBalance[]) => void;
   /** Update network when the user switches chains */
@@ -79,6 +86,7 @@ const initialState: WalletState = {
   isLoadingBalances: false,
   error: null,
   shouldAutoReconnect: false,
+  queryClient: null,
 };
 
 // ─── Store ────────────────────────────────────────────────────────────────────
@@ -86,7 +94,7 @@ const initialState: WalletState = {
 export const useWalletStore = create<WalletStore>()(
   devtools(
     persist(
-      (set) => ({
+      (set, get) => ({
         ...initialState,
 
         setConnected: (address, network) =>
@@ -110,6 +118,39 @@ export const useWalletStore = create<WalletStore>()(
             false,
             "wallet/disconnect",
           ),
+
+        disconnectAndCleanup: () => {
+          const { queryClient } = get();
+          
+          // Cancel all pending queries and mutations
+          if (queryClient) {
+            queryClient.cancelQueries({});
+            queryClient.cancelMutations();
+            // Clear query cache for wallet-specific data
+            queryClient.removeQueries({ queryKey: ["loans"] });
+            queryClient.removeQueries({ queryKey: ["remittances"] });
+            queryClient.removeQueries({ queryKey: ["pool"] });
+            queryClient.removeQueries({ queryKey: ["scoreBreakdown"] });
+            queryClient.removeQueries({ queryKey: ["creditScore"] });
+            queryClient.removeQueries({ queryKey: ["yieldHistory"] });
+            queryClient.removeQueries({ queryKey: ["remittanceNft"] });
+            queryClient.removeQueries({ queryKey: ["notifications"] });
+            queryClient.removeQueries({ queryKey: ["notificationPreferences"] });
+            queryClient.removeQueries({ queryKey: ["user"] });
+          }
+          
+          // Reset to initial state
+          set(
+            {
+              ...initialState,
+            },
+            false,
+            "wallet/disconnectAndCleanup",
+          );
+        },
+
+        setQueryClient: (client: QueryClient) =>
+          set({ queryClient: client }, false, "wallet/setQueryClient"),
 
         setBalances: (balances) =>
           set({ balances, isLoadingBalances: false }, false, "wallet/setBalances"),


### PR DESCRIPTION
## Summary

This PR fixes the issue where disconnecting the wallet does not clear client state or cancel pending requests, leading to confusing errors.

## Changes

### Enhanced Wallet Store
- Added  to wallet store for cleanup access
- Added  function that:
  - Cancels all pending TanStack Query mutations and queries
  - Removes wallet-specific query cache (loans, remittances, pool, score, credit, yield, NFTs, notifications)
  - Resets wallet state to initial values

### Updated WalletProvider
- Sets queryClient in wallet store on mount
- Uses enhanced  for both manual disconnect and Freighter account change events
- Properly cleans up when user switches accounts in Freighter

### Event Listener Updates
- Freighter  callback now uses enhanced disconnect when account is removed
- Freighter  continues to refresh wallet on network change

## How It Works

1. **User clicks disconnect** →  called → all pending requests cancelled → cache cleared → state reset
2. **User switches account in Freighter** →  fires with empty address →  called → same cleanup
3. **User switches network** →  fires →  called → wallet reconnects with new network

## Issue References

Closes #147
Closes #148
Closes #149
Closes #150
