### PR TITLE
feat(frontend): i18n admin pages and Next.js image optimization (#106…

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -81,7 +81,12 @@
     "activity": "Activity",
     "notifications": "Notifications",
     "liquidations": "Liquidations",
-    "adminDisputes": "Disputes"
+    "adminDisputes": "Disputes",
+    "lend": "Lend",
+    "wallet": "Wallet",
+    "walletStatus": "Wallet Status",
+    "disconnected": "Disconnected",
+    "connected": "Connected"
   },
   "Loans": {
     "title": "Loans",
@@ -197,6 +202,9 @@
     "contactSupport": "Contact Support",
     "viewDetails": "View Details",
     "details": "Details"
+  },
+  "AdminLayout": {
+    "adminArea": "Admin Area"
   },
   "AdminDisputes": {
     "eyebrow": "Admin Review",
@@ -363,6 +371,10 @@
     "currentAdmin": "Current admin",
     "targetContract": "Target contract",
     "expiresAt": "Expires at",
-    "timeToExecutable": "Time to executable"
+    "timeToExecutable": "Time to executable",
+    "notConfigured": "Not configured",
+    "notScheduled": "Not scheduled",
+    "unknown": "Unknown",
+    "executableNow": "Executable now"
   }
 }

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -81,7 +81,12 @@
     "activity": "Actividad",
     "notifications": "Notificaciones",
     "liquidations": "Liquidaciones",
-    "adminDisputes": "Disputas"
+    "adminDisputes": "Disputas",
+    "lend": "Prestar",
+    "wallet": "Billetera",
+    "walletStatus": "Estado de billetera",
+    "disconnected": "Desconectada",
+    "connected": "Conectada"
   },
   "Loans": {
     "title": "Préstamos",
@@ -197,6 +202,9 @@
     "contactSupport": "Contactar soporte",
     "viewDetails": "Ver detalles",
     "details": "Detalles"
+  },
+  "AdminLayout": {
+    "adminArea": "Área de administración"
   },
   "AdminDisputes": {
     "eyebrow": "Consola admin",
@@ -363,6 +371,10 @@
     "currentAdmin": "Administrador actual",
     "targetContract": "Contrato objetivo",
     "expiresAt": "Expira",
-    "timeToExecutable": "Tiempo hasta ejecutable"
+    "timeToExecutable": "Tiempo hasta ejecutable",
+    "notConfigured": "No configurado",
+    "notScheduled": "No programado",
+    "unknown": "Desconocido",
+    "executableNow": "Ejecutable ahora"
   }
 }

--- a/frontend/messages/tl.json
+++ b/frontend/messages/tl.json
@@ -81,7 +81,12 @@
     "activity": "Aktibidad",
     "notifications": "Mga Notification",
     "liquidations": "Mga Liquidasyon",
-    "adminDisputes": "Mga Dispute"
+    "adminDisputes": "Mga Dispute",
+    "lend": "Magpautang",
+    "wallet": "Wallet",
+    "walletStatus": "Status ng Wallet",
+    "disconnected": "Nakaputol",
+    "connected": "Nakakonekta"
   },
   "Loans": {
     "title": "Mga Loan",
@@ -197,6 +202,9 @@
     "contactSupport": "Kontakin ang Support",
     "viewDetails": "Tingnan ang Mga Detalye",
     "details": "Mga Detalye"
+  },
+  "AdminLayout": {
+    "adminArea": "Lugar ng Admin"
   },
   "AdminDisputes": {
     "eyebrow": "Pagsusuri ng Admin",
@@ -363,6 +371,10 @@
     "currentAdmin": "Kasalukuyang admin",
     "targetContract": "Target na kontrata",
     "expiresAt": "Mawawalan ng bisa",
-    "timeToExecutable": "Oras hanggang sa maipatupad"
+    "timeToExecutable": "Oras hanggang sa maipatupad",
+    "notConfigured": "Hindi naka-configure",
+    "notScheduled": "Hindi naka-iskedyul",
+    "unknown": "Hindi alam",
+    "executableNow": "Maaaring ipatupad ngayon"
   }
 }

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -12,6 +12,29 @@ const withSerwist = withSerwistInit({
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
+  images: {
+    // Serve modern formats automatically (WebP, then AVIF for further savings)
+    formats: ["image/avif", "image/webp"],
+    // Common responsive breakpoints covering mobile → 4 K displays
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
+    // Icon / thumbnail sizes used in the app
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+    // Remote patterns: allow the OG image host and the Stellar Horizon CDN
+    remotePatterns: [
+      {
+        // Allow images served from the same configured app URL (e.g. Vercel preview URLs)
+        protocol: "https",
+        hostname: "remitlend.com",
+      },
+      {
+        // Stellar Expert uses this host for account/asset icons
+        protocol: "https",
+        hostname: "**.stellar.expert",
+      },
+    ],
+    // Minimum cache TTL for optimized images: 7 days
+    minimumCacheTTL: 60 * 60 * 24 * 7,
+  },
 };
 
 const config = withSerwist(nextConfig);

--- a/frontend/src/app/[locale]/admin/governance/page.tsx
+++ b/frontend/src/app/[locale]/admin/governance/page.tsx
@@ -4,23 +4,23 @@ import { useTranslations } from "next-intl";
 import { useAdminGovernancePending } from "../../../hooks/useApi";
 import { useUserStore } from "../../../stores/useUserStore";
 
-function shortAddress(value: string | null | undefined) {
-  if (!value) return "Not configured";
-  return value.length > 14 ? `${value.slice(0, 8)}...${value.slice(-6)}` : value;
-}
-
-function timeUntil(value: string | null | undefined) {
-  if (!value) return "Not scheduled";
-  const deltaMs = new Date(value).getTime() - Date.now();
-  if (!Number.isFinite(deltaMs)) return "Unknown";
-  if (deltaMs <= 0) return "Executable now";
-  const minutes = Math.ceil(deltaMs / 60_000);
-  if (minutes < 60) return `${minutes}m`;
-  return `${Math.ceil(minutes / 60)}h`;
-}
-
 export default function GovernancePage() {
   const t = useTranslations("Governance");
+
+  function shortAddress(value: string | null | undefined) {
+    if (!value) return t("notConfigured");
+    return value.length > 14 ? `${value.slice(0, 8)}...${value.slice(-6)}` : value;
+  }
+
+  function timeUntil(value: string | null | undefined) {
+    if (!value) return t("notScheduled");
+    const deltaMs = new Date(value).getTime() - Date.now();
+    if (!Number.isFinite(deltaMs)) return t("unknown");
+    if (deltaMs <= 0) return t("executableNow");
+    const minutes = Math.ceil(deltaMs / 60_000);
+    if (minutes < 60) return `${minutes}m`;
+    return `${Math.ceil(minutes / 60)}h`;
+  }
   const role = useUserStore((state) => state.user?.role);
   const { data, isLoading, isError } = useAdminGovernancePending();
 
@@ -100,7 +100,7 @@ export default function GovernancePage() {
                 <div>
                   <p className="text-xs uppercase tracking-wide text-zinc-500">{t("expiresAt")}</p>
                   <p className="mt-1 text-sm text-zinc-950 dark:text-zinc-50">
-                    {data.pendingProposal.expiresAt ?? "Not configured"}
+                    {data.pendingProposal.expiresAt ?? t("notConfigured")}
                   </p>
                 </div>
               </div>

--- a/frontend/src/app/[locale]/admin/layout.tsx
+++ b/frontend/src/app/[locale]/admin/layout.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+import { getTranslations } from "next-intl/server";
+import { LanguageSwitcher } from "../../components/global_ui/LanguageSwitcher";
+import { ShieldCheck } from "lucide-react";
+
+interface AdminLayoutProps {
+  children: ReactNode;
+}
+
+export default async function AdminLayout({ children }: AdminLayoutProps) {
+  const t = await getTranslations("AdminLayout");
+
+  return (
+    <div className="min-h-screen">
+      {/* Admin section banner */}
+      <div className="border-b border-amber-200 bg-amber-50 dark:border-amber-900/50 dark:bg-amber-950/20">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-2 sm:px-6 lg:px-8">
+          <div className="flex items-center gap-2 text-sm font-medium text-amber-700 dark:text-amber-400">
+            <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+            <span>{t("adminArea")}</span>
+          </div>
+          <LanguageSwitcher />
+        </div>
+      </div>
+
+      {/* Page content */}
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/app/components/global_ui/Sidebar.tsx
+++ b/frontend/src/app/components/global_ui/Sidebar.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { usePathname } from "next/navigation";
 import {
   LayoutDashboard,
   HandCoins,
   PiggyBank,
-  SendHorizontal,
-  Settings,
   X,
   CreditCard,
   Clock,
@@ -61,10 +60,10 @@ export function Sidebar({ onClose, className }: SidebarProps) {
   const navItems = [
     { name: t("home"), href: `/${locale}`, icon: LayoutDashboard },
     { name: t("loans"), href: `/${locale}/loans`, icon: HandCoins },
-    { name: "Lend", href: `/${locale}/lend`, icon: PiggyBank },
+    { name: t("lend"), href: `/${locale}/lend`, icon: PiggyBank },
     { name: t("liquidations"), href: `/${locale}/liquidations`, icon: ShieldAlert },
     { name: t("activity"), href: `/${locale}/activity`, icon: Clock },
-    { name: "Wallet", href: `/${locale}/wallet`, icon: CreditCard },
+    { name: t("wallet"), href: `/${locale}/wallet`, icon: CreditCard },
     ...(isAdmin
       ? [{ name: t("adminDisputes"), href: `/${locale}/admin/disputes`, icon: ShieldAlert }]
       : []),
@@ -80,9 +79,14 @@ export function Sidebar({ onClose, className }: SidebarProps) {
     >
       <div className="flex h-16 items-center justify-between px-6 border-b border-zinc-200 dark:border-zinc-800">
         <Link href={`/${locale}`} className="flex items-center gap-2">
-          <div className="h-8 w-8 rounded-lg bg-indigo-600 flex items-center justify-center">
-            <SendHorizontal className="h-5 w-5 text-white" />
-          </div>
+          <Image
+            src="/images/logo.png"
+            alt="RemitLend"
+            width={32}
+            height={32}
+            priority
+            className="rounded-lg"
+          />
           <span className="text-xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
             RemitLend
           </span>
@@ -132,7 +136,7 @@ export function Sidebar({ onClose, className }: SidebarProps) {
       <div className="p-4 border-t border-zinc-200 dark:border-zinc-800">
         <div className="rounded-xl bg-zinc-50 p-4 dark:bg-zinc-900">
           <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-            Wallet Status
+            {t("walletStatus")}
           </p>
           <div className="flex items-center gap-2">
             <div
@@ -142,7 +146,7 @@ export function Sidebar({ onClose, className }: SidebarProps) {
               )}
             />
             <span className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
-              {isConnected ? `${network?.name || "Connected"}` : "Disconnected"}
+              {isConnected ? `${network?.name || t("connected")}` : t("disconnected")}
             </span>
           </div>
         </div>


### PR DESCRIPTION
…, #107)

## #106 – Internationalize admin pages and hardcoded English strings

### Translation files (en.json / es.json / tl.json)
- Add Governance fallback keys: notConfigured, notScheduled, unknown, executableNow (previously returned bare English strings from helpers)
- Add Navigation keys: lend, wallet, walletStatus, connected, disconnected (Sidebar nav items and wallet status footer were hardcoded English)
- Add AdminLayout.adminArea key (translated in all three locales)

### admin/governance/page.tsx
- Move shortAddress() and timeUntil() inside GovernancePage so they can call t() — eliminates 5 hardcoded English fallback strings

### Sidebar.tsx
- Replace hardcoded 'Lend', 'Wallet', 'Wallet Status', 'Connected', 'Disconnected' with t() calls from the Navigation namespace

### admin/layout.tsx (new)
- Dedicated layout for all /admin/* routes
- Renders an amber admin-area banner with a ShieldCheck icon and an inline <LanguageSwitcher /> so locale can be changed from any admin page without relying solely on the top-level Header

## #107 – Next.js image optimization and lazy loading strategy

### next.config.ts
- images.formats: ['image/avif', 'image/webp'] — modern format serving
- images.deviceSizes / imageSizes — standard responsive breakpoint set
- images.remotePatterns — allow remitlend.com and *.stellar.expert hosts
- images.minimumCacheTTL: 604800 — 7-day cache for optimised images

### Sidebar.tsx
- Replace placeholder div+icon logo with <Image src='/images/logo.png' width={32} height={32} priority /> — priority flag triggers preload for the above-fold logo, directly improving LCP; all other images default to lazy loading via next/image
- Remove now-unused SendHorizontal and Settings lucide imports

Closes #106
Closes #107

## Pull Request Checklist

Please ensure your PR follows these steps, mirroring our `CONTRIBUTING.md` guidelines.

- [ ] I have read the `CONTRIBUTING.md` document.
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [ ] I have verified the changes locally.
closes #105 
closes #106 
closes #107 
closes #108 