### PR TITLE
feat(frontend): resolve issues #139-#142

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,9 @@ jobs:
       - name: Type check
         run: npm run typecheck
         working-directory: frontend
+      - name: Check translation parity
+        run: npm run i18n:check
+        working-directory: frontend
       - name: Unit tests
         run: npm test
         working-directory: frontend
@@ -233,6 +236,9 @@ jobs:
           NODE_ENV: test
       - name: Build
         run: npm run build
+        working-directory: frontend
+      - name: Check performance budget
+        run: npm run performance:budget
         working-directory: frontend
 
   scripts-typecheck:

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -44,6 +44,19 @@ Developed a cohesive visual language built around:
 - Dark mode first — optimized for extended sessions and Web3 aesthetics
 - Consistency — shared component language across all dashboard views
 
+## Component Organization
+
+Shared UI is exposed through three stable layers under `frontend/src/app/components`:
+
+- `atoms`: primitive controls and visual building blocks
+- `molecules`: small combinations of atoms with a focused interaction
+- `organisms`: complete dashboard sections and resilient feature surfaces
+
+Feature-specific components remain grouped by domain (`borrower`, `loan-wizard`, `charts`, and
+`transaction`). New shared components should be added to the smallest appropriate layer and
+exported from its `index.ts`; consumers should import through the layer entry point rather than
+reaching into another feature's implementation.
+
 ---
 
 ## Color Palette

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "recharts": "^3.8.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
+        "web-vitals": "^6.2.1",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -13839,6 +13840,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.2.1.tgz",
+      "integrity": "sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw==",
+      "license": "Apache-2.0"
     },
     "node_modules/webpack": {
       "version": "5.106.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "performance:budget": "node scripts/check-performance-budget.mjs",
+    "i18n:check": "node scripts/check-i18n.mjs",
     "start": "next start",
     "lint": "prettier --check .",
     "typecheck": "tsc --noEmit",
@@ -40,6 +42,7 @@
     "react-dom": "19.2.3",
     "recharts": "^3.8.1",
     "sonner": "^2.0.7",
+    "web-vitals": "^6.2.1",
     "tailwind-merge": "^3.5.0",
     "zod": "^3.23.0",
     "zustand": "^5.0.12"

--- a/frontend/scripts/check-i18n.mjs
+++ b/frontend/scripts/check-i18n.mjs
@@ -1,0 +1,31 @@
+import { readFile } from "node:fs/promises";
+
+const locales = ["en", "es", "tl"];
+
+function flatten(value, prefix = "") {
+  return Object.entries(value).flatMap(([key, child]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+    return child && typeof child === "object" ? flatten(child, path) : [path];
+  });
+}
+
+const messages = Object.fromEntries(
+  await Promise.all(
+    locales.map(async (locale) => [locale, JSON.parse(await readFile(`messages/${locale}.json`, "utf8"))]),
+  ),
+);
+const referenceKeys = new Set(flatten(messages.en));
+let failed = false;
+
+for (const locale of locales.slice(1)) {
+  const keys = new Set(flatten(messages[locale]));
+  for (const key of referenceKeys) {
+    if (!keys.has(key)) {
+      console.error(`${locale}.json is missing ${key}`);
+      failed = true;
+    }
+  }
+}
+
+if (failed) process.exit(1);
+console.log(`Translation key parity passed for ${locales.join(", ")}`);

--- a/frontend/scripts/check-performance-budget.mjs
+++ b/frontend/scripts/check-performance-budget.mjs
@@ -1,0 +1,30 @@
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+const budgetBytes = Number(process.env.NEXT_PERFORMANCE_BUDGET_BYTES ?? 2_000_000);
+const chunksDirectory = "./.next/static/chunks";
+
+async function getJavaScriptBytes(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const sizes = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) return getJavaScriptBytes(path);
+      if (!entry.name.endsWith(".js")) return 0;
+      return (await stat(path)).size;
+    }),
+  );
+  return sizes.flat(Infinity).reduce((total, size) => total + size, 0);
+}
+
+try {
+  const bytes = await getJavaScriptBytes(chunksDirectory);
+  if (bytes > budgetBytes) {
+    console.error(`Performance budget exceeded: ${bytes} bytes > ${budgetBytes} bytes`);
+    process.exit(1);
+  }
+  console.log(`Performance budget passed: ${bytes} bytes <= ${budgetBytes} bytes`);
+} catch (error) {
+  console.error("Performance budget could not inspect the production build", error);
+  process.exit(1);
+}

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -1,5 +1,3 @@
-import { NextIntlClientProvider } from "next-intl";
-import { getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
@@ -20,11 +18,5 @@ export default async function LocaleLayout({
     notFound();
   }
 
-  const messages = await getMessages();
-
-  return (
-    <NextIntlClientProvider messages={messages} locale={locale}>
-      {children}
-    </NextIntlClientProvider>
-  );
+  return children;
 }

--- a/frontend/src/app/api/analytics/vitals/route.ts
+++ b/frontend/src/app/api/analytics/vitals/route.ts
@@ -1,0 +1,27 @@
+import * as Sentry from "@sentry/nextjs";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const vitalSchema = z.object({
+  name: z.enum(["CLS", "INP", "LCP"]),
+  value: z.number().finite().nonnegative(),
+  rating: z.enum(["good", "needs-improvement", "poor"]),
+  id: z.string().min(1).max(128),
+  path: z.string().min(1).max(2048),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = vitalSchema.safeParse(await request.json().catch(() => null));
+  if (!result.success) {
+    return NextResponse.json({ error: "Invalid metric" }, { status: 400 });
+  }
+
+  Sentry.captureEvent({
+    message: `Web Vital: ${result.data.name}`,
+    level: result.data.rating === "poor" ? "warning" : "info",
+    tags: { metric: result.data.name, rating: result.data.rating },
+    extra: { value: result.data.value, id: result.data.id, path: result.data.path },
+  });
+
+  return NextResponse.json({ accepted: true }, { status: 202 });
+}

--- a/frontend/src/app/components/atoms/index.ts
+++ b/frontend/src/app/components/atoms/index.ts
@@ -1,0 +1,4 @@
+export { Button } from "../ui/Button";
+export { Card, CardContent, CardHeader, CardTitle } from "../ui/Card";
+export { Input } from "../ui/Input";
+export { Skeleton } from "../ui/Skeleton";

--- a/frontend/src/app/components/dashboards/FinancialPerformanceDashboard.tsx
+++ b/frontend/src/app/components/dashboards/FinancialPerformanceDashboard.tsx
@@ -33,6 +33,7 @@ import { Button } from "../ui/Button";
 import { AnalyticsSkeleton } from "../skeletons/AnalyticsSkeleton";
 import { SkeletonChart } from "../ui/Skeleton";
 import { RefreshCw, CheckCircle2, TrendingUp, DollarSign, Activity } from "lucide-react";
+import { ErrorBoundary } from "../global_ui/ErrorBoundary";
 
 interface FinancialPerformanceDashboardProps {
   userId: string;
@@ -373,7 +374,9 @@ export function FinancialPerformanceDashboard({
             </Card>
           ) : (
             <Suspense fallback={<SkeletonChart />}>
-              <CreditScoreTrendChart data={displayCreditScoreData} />
+              <ErrorBoundary scope="credit score chart" variant="section">
+                <CreditScoreTrendChart data={displayCreditScoreData} />
+              </ErrorBoundary>
             </Suspense>
           )}
 
@@ -466,13 +469,17 @@ export function FinancialPerformanceDashboard({
             </Card>
           ) : (
             <Suspense fallback={<SkeletonChart />}>
-              <YieldEarningsChart data={displayYieldData} />
+              <ErrorBoundary scope="yield chart" variant="section">
+                <YieldEarningsChart data={displayYieldData} />
+              </ErrorBoundary>
             </Suspense>
           )}
 
           {/* Active loan risk tier breakdown */}
           <Suspense fallback={<SkeletonChart />}>
-            <RiskTierChart data={displayRiskTierData} />
+            <ErrorBoundary scope="risk tier chart" variant="section">
+              <RiskTierChart data={displayRiskTierData} />
+            </ErrorBoundary>
           </Suspense>
         </div>
       )}

--- a/frontend/src/app/components/global_ui/ErrorBoundary.tsx
+++ b/frontend/src/app/components/global_ui/ErrorBoundary.tsx
@@ -3,6 +3,7 @@
 import React, { Component, type ErrorInfo, type ReactNode } from "react";
 import Link from "next/link";
 import { RefreshCcw, Siren, TriangleAlert } from "lucide-react";
+import * as Sentry from "@sentry/nextjs";
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -122,6 +123,11 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     console.error("ErrorBoundary caught an error:", error, errorInfo);
+    Sentry.withScope((scope) => {
+      scope.setTag("error_boundary", this.props.scope ?? "section");
+      scope.setContext("component", { componentStack: errorInfo.componentStack });
+      Sentry.captureException(error);
+    });
   }
 
   handleReset = (): void => {

--- a/frontend/src/app/components/molecules/index.ts
+++ b/frontend/src/app/components/molecules/index.ts
@@ -1,0 +1,4 @@
+export { EmptyState } from "../ui/EmptyState";
+export { LoanStatusBadge } from "../ui/LoanStatusBadge";
+export { PaginationControls } from "../ui/PaginationControls";
+export { StatusIndicator } from "../ui/StatusIndicator";

--- a/frontend/src/app/components/organisms/index.ts
+++ b/frontend/src/app/components/organisms/index.ts
@@ -1,0 +1,4 @@
+export { DashboardShell } from "../global_ui/DashboardShell";
+export { ErrorBoundary, ErrorFallback } from "../global_ui/ErrorBoundary";
+export { FinancialPerformanceDashboard } from "../dashboards/FinancialPerformanceDashboard";
+export { LoanDashboard } from "../borrower/LoanDashboard";

--- a/frontend/src/app/components/providers/WebVitalsReporter.tsx
+++ b/frontend/src/app/components/providers/WebVitalsReporter.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { onCLS, onINP, onLCP, type Metric } from "web-vitals";
+
+const VITALS_ENDPOINT = "/api/analytics/vitals";
+
+function reportMetric(metric: Metric): void {
+  const payload = JSON.stringify({
+    name: metric.name,
+    value: metric.value,
+    rating: metric.rating,
+    id: metric.id,
+    path: window.location.pathname,
+  });
+
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon(VITALS_ENDPOINT, new Blob([payload], { type: "application/json" }));
+    return;
+  }
+
+  void fetch(VITALS_ENDPOINT, {
+    method: "POST",
+    body: payload,
+    headers: { "Content-Type": "application/json" },
+    keepalive: true,
+  });
+}
+
+export function WebVitalsReporter(): null {
+  useEffect(() => {
+    onCLS(reportMetric);
+    onINP(reportMetric);
+    onLCP(reportMetric);
+  }, []);
+
+  return null;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 import { THEME_STORAGE_KEY } from "./lib/theme";
 import { getSiteUrl } from "./lib/metadata";
+import { WebVitalsReporter } from "./components/providers/WebVitalsReporter";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -50,6 +51,7 @@ export default async function RootLayout({
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <NextIntlClientProvider locale={locale} messages={messages}>
           <QueryProvider>
+            <WebVitalsReporter />
             <WalletProvider>
               <DashboardShell>
                 <ErrorBoundary scope="active page" variant="section">

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -6,6 +6,7 @@ export default createMiddleware({
 
   // Used when no locale matches
   defaultLocale: "en",
+  localeDetection: true,
 });
 
 export const config = {


### PR DESCRIPTION
## Summary

- Add locale detection and enforce translation-key parity for English, Spanish, and Tagalog.
- Add Web Vitals collection for CLS, INP, and LCP with validated analytics ingestion through Sentry.
- Establish documented atoms, molecules, and organisms entry points for shared UI reuse.
- Add Sentry component-stack reporting and isolate analytics chart failures with resettable fallbacks.
- Add JavaScript performance budgets to CI after production builds.

## Validation

- `node scripts/check-i18n.mjs`
- `node --check scripts/check-performance-budget.mjs`
- `git diff --check`
- Full dependency install/typecheck was blocked by the pre-existing `openapi-zod-generator@^1.0.0` registry 404.

Closes #139
Closes #140
Closes #141
Closes #142