### PR TITLE
feat(frontend): chart primitives, disconnect cleanup, mobile nav & copy UX

### DIFF
--- a/frontend/src/app/components/charts/primitives/index.tsx
+++ b/frontend/src/app/components/charts/primitives/index.tsx
@@ -1,0 +1,476 @@
+"use client";
+
+/**
+ * Accessible, animation-aware chart primitives built on Recharts.
+ *
+ * Every chart here:
+ *  - renders inside a labelled `<figure>` with a `<figcaption>`;
+ *  - exposes the underlying data as a visually-hidden `<table>` so screen
+ *    readers get the numbers, not just "chart";
+ *  - enables Recharts' `accessibilityLayer` for keyboard navigation of points;
+ *  - disables entry animations when the user has `prefers-reduced-motion: reduce`.
+ *
+ * Prefer these over hand-rolling Recharts in feature code.
+ */
+
+import { useMemo, type ReactNode } from "react";
+import {
+  Area,
+  AreaChart as RcAreaChart,
+  Bar,
+  BarChart as RcBarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Line,
+  LineChart as RcLineChart,
+  Pie,
+  PieChart as RcPieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { useReducedMotion } from "framer-motion";
+import { cn } from "@/app/utils/cn";
+import { Skeleton } from "../../ui/Skeleton";
+
+/** Brand-neutral categorical palette, reused across every chart. */
+export const CHART_COLORS = [
+  "#6366f1", // indigo
+  "#10b981", // emerald
+  "#f59e0b", // amber
+  "#3b82f6", // blue
+  "#ec4899", // pink
+  "#8b5cf6", // violet
+];
+
+export interface ChartSeries {
+  /** Key into each data row. */
+  key: string;
+  /** Human label shown in the legend, tooltip and SR table. */
+  label: string;
+  /** Overrides the palette colour for this series. */
+  color?: string;
+}
+
+export interface BaseChartProps {
+  data: Array<Record<string, string | number>>;
+  /** Key used for the category / x-axis. */
+  xKey: string;
+  series: ChartSeries[];
+  /** Required — becomes the figure's accessible name. */
+  title: string;
+  /** Optional longer description rendered in the caption. */
+  description?: string;
+  height?: number;
+  loading?: boolean;
+  className?: string;
+  /** Formats numeric values in axes, tooltips and the SR table. */
+  valueFormatter?: (value: number) => string;
+}
+
+const defaultFormatter = (value: number) => `${value}`;
+
+/** Wraps a numeric formatter so it is safe to hand to Recharts' `formatter`. */
+const toRechartsFormatter =
+  (fn: (value: number) => string) =>
+  (value: number | string): string =>
+    fn(Number(value));
+
+const listLabels = (series: ChartSeries[]) => series.map((s) => s.label).join(", ");
+
+/** Builds the screen-reader summary sentence rendered after each chart. */
+function srCaptionFor(
+  kind: string,
+  title: string,
+  count: number,
+  unit: string,
+  series: ChartSeries[],
+) {
+  return `${title}: ${kind} with ${count} ${unit} across ${listLabels(series)}.`;
+}
+
+function seriesColor(s: ChartSeries, i: number) {
+  return s.color ?? CHART_COLORS[i % CHART_COLORS.length];
+}
+
+/** Loading placeholder for any chart. Respects reduced motion via `Skeleton`. */
+export function ChartSkeleton({
+  height = 300,
+  className,
+}: {
+  height?: number;
+  className?: string;
+}) {
+  return (
+    <div
+      role="status"
+      aria-label="Loading chart"
+      className={cn(
+        "rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-950",
+        className,
+      )}
+    >
+      <Skeleton className="mb-4 h-5 w-40" />
+      <Skeleton className="w-full rounded-lg" style={{ height }} />
+      <div className="mt-4 flex gap-3">
+        <Skeleton className="h-3 w-16" />
+        <Skeleton className="h-3 w-16" />
+        <Skeleton className="h-3 w-16" />
+      </div>
+    </div>
+  );
+}
+
+/** Screen-reader-only tabular representation of the chart data. */
+function DataTable({
+  data,
+  xKey,
+  series,
+  caption,
+  valueFormatter,
+}: Pick<BaseChartProps, "data" | "xKey" | "series"> & {
+  caption: string;
+  valueFormatter: (value: number) => string;
+}) {
+  return (
+    <table className="sr-only">
+      <caption>{caption}</caption>
+      <thead>
+        <tr>
+          <th scope="col">{xKey}</th>
+          {series.map((s) => (
+            <th key={s.key} scope="col">
+              {s.label}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row, i) => (
+          <tr key={i}>
+            <th scope="row">{String(row[xKey])}</th>
+            {series.map((s) => (
+              <td key={s.key}>
+                {typeof row[s.key] === "number"
+                  ? valueFormatter(row[s.key] as number)
+                  : String(row[s.key] ?? "")}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+interface ChartFigureProps extends Pick<BaseChartProps, "title" | "description" | "className"> {
+  srCaption: string;
+  table: ReactNode;
+  children: ReactNode;
+}
+
+function ChartFigure({
+  title,
+  description,
+  className,
+  srCaption,
+  table,
+  children,
+}: ChartFigureProps) {
+  return (
+    <figure
+      className={cn("m-0", className)}
+      role="group"
+      aria-label={description ? `${title}. ${description}` : title}
+    >
+      <figcaption className="mb-2 text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        {title}
+        {description && (
+          <span className="block text-xs font-normal text-zinc-500 dark:text-zinc-400">
+            {description}
+          </span>
+        )}
+      </figcaption>
+      {table}
+      <div aria-hidden="true">{children}</div>
+      <p className="sr-only">{srCaption}</p>
+    </figure>
+  );
+}
+
+const axisProps = {
+  tick: { fill: "currentColor", fontSize: 12 },
+  tickLine: { stroke: "currentColor" },
+  className: "text-zinc-500 dark:text-zinc-400",
+} as const;
+
+const tooltipProps = {
+  contentStyle: {
+    borderRadius: 12,
+    border: "1px solid var(--tw-prose-hr, #e4e4e7)",
+    background: "rgba(255,255,255,0.98)",
+    fontSize: 12,
+  },
+  wrapperClassName: "dark:[&_.recharts-tooltip-item]:!text-zinc-200",
+} as const;
+
+function useAnimation() {
+  const reduced = useReducedMotion();
+  return { isAnimationActive: !reduced, animationDuration: reduced ? 0 : 600 };
+}
+
+/* ─────────────────────────────  Line  ────────────────────────────── */
+
+export function LineChart(props: BaseChartProps) {
+  const { data, xKey, series, height = 300, loading, valueFormatter = defaultFormatter } = props;
+  const anim = useAnimation();
+  const srCaption = useMemo(
+    () => srCaptionFor("line chart", props.title, data.length, "points", series),
+    [props.title, data.length, series],
+  );
+
+  if (loading) return <ChartSkeleton height={height} className={props.className} />;
+
+  return (
+    <ChartFigure
+      {...props}
+      srCaption={srCaption}
+      table={
+        <DataTable
+          data={data}
+          xKey={xKey}
+          series={series}
+          caption={props.title}
+          valueFormatter={valueFormatter}
+        />
+      }
+    >
+      <ResponsiveContainer width="100%" height={height}>
+        <RcLineChart
+          data={data}
+          margin={{ top: 5, right: 16, left: 0, bottom: 5 }}
+          accessibilityLayer
+        >
+          <CartesianGrid strokeDasharray="3 3" className="stroke-zinc-200 dark:stroke-zinc-800" />
+          <XAxis dataKey={xKey} {...axisProps} />
+          <YAxis {...axisProps} tickFormatter={valueFormatter} />
+          <Tooltip {...tooltipProps} formatter={toRechartsFormatter(valueFormatter)} />
+          <Legend />
+          {series.map((s, i) => (
+            <Line
+              key={s.key}
+              type="monotone"
+              dataKey={s.key}
+              name={s.label}
+              stroke={seriesColor(s, i)}
+              strokeWidth={2}
+              dot={false}
+              {...anim}
+            />
+          ))}
+        </RcLineChart>
+      </ResponsiveContainer>
+    </ChartFigure>
+  );
+}
+
+/* ─────────────────────────────  Area  ────────────────────────────── */
+
+export function AreaChart(props: BaseChartProps) {
+  const { data, xKey, series, height = 300, loading, valueFormatter = defaultFormatter } = props;
+  const anim = useAnimation();
+  const srCaption = srCaptionFor("area chart", props.title, data.length, "points", series);
+
+  if (loading) return <ChartSkeleton height={height} className={props.className} />;
+
+  return (
+    <ChartFigure
+      {...props}
+      srCaption={srCaption}
+      table={
+        <DataTable
+          data={data}
+          xKey={xKey}
+          series={series}
+          caption={props.title}
+          valueFormatter={valueFormatter}
+        />
+      }
+    >
+      <ResponsiveContainer width="100%" height={height}>
+        <RcAreaChart
+          data={data}
+          margin={{ top: 5, right: 16, left: 0, bottom: 5 }}
+          accessibilityLayer
+        >
+          <defs>
+            {series.map((s, i) => (
+              <linearGradient key={s.key} id={`grad-${s.key}`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={seriesColor(s, i)} stopOpacity={0.7} />
+                <stop offset="95%" stopColor={seriesColor(s, i)} stopOpacity={0.05} />
+              </linearGradient>
+            ))}
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" className="stroke-zinc-200 dark:stroke-zinc-800" />
+          <XAxis dataKey={xKey} {...axisProps} />
+          <YAxis {...axisProps} tickFormatter={valueFormatter} />
+          <Tooltip {...tooltipProps} formatter={toRechartsFormatter(valueFormatter)} />
+          <Legend />
+          {series.map((s, i) => (
+            <Area
+              key={s.key}
+              type="monotone"
+              dataKey={s.key}
+              name={s.label}
+              stroke={seriesColor(s, i)}
+              strokeWidth={2}
+              fill={`url(#grad-${s.key})`}
+              {...anim}
+            />
+          ))}
+        </RcAreaChart>
+      </ResponsiveContainer>
+    </ChartFigure>
+  );
+}
+
+/* ─────────────────────────────  Bar  ─────────────────────────────── */
+
+export function BarChart(props: BaseChartProps & { stacked?: boolean }) {
+  const {
+    data,
+    xKey,
+    series,
+    height = 300,
+    loading,
+    stacked,
+    valueFormatter = defaultFormatter,
+  } = props;
+  const anim = useAnimation();
+  const srCaption = srCaptionFor("bar chart", props.title, data.length, "categories", series);
+
+  if (loading) return <ChartSkeleton height={height} className={props.className} />;
+
+  return (
+    <ChartFigure
+      {...props}
+      srCaption={srCaption}
+      table={
+        <DataTable
+          data={data}
+          xKey={xKey}
+          series={series}
+          caption={props.title}
+          valueFormatter={valueFormatter}
+        />
+      }
+    >
+      <ResponsiveContainer width="100%" height={height}>
+        <RcBarChart
+          data={data}
+          margin={{ top: 5, right: 16, left: 0, bottom: 5 }}
+          accessibilityLayer
+        >
+          <CartesianGrid strokeDasharray="3 3" className="stroke-zinc-200 dark:stroke-zinc-800" />
+          <XAxis dataKey={xKey} {...axisProps} />
+          <YAxis {...axisProps} tickFormatter={valueFormatter} />
+          <Tooltip
+            {...tooltipProps}
+            formatter={toRechartsFormatter(valueFormatter)}
+            cursor={{ opacity: 0.1 }}
+          />
+          <Legend />
+          {series.map((s, i) => (
+            <Bar
+              key={s.key}
+              dataKey={s.key}
+              name={s.label}
+              fill={seriesColor(s, i)}
+              radius={[4, 4, 0, 0]}
+              stackId={stacked ? "stack" : undefined}
+              {...anim}
+            />
+          ))}
+        </RcBarChart>
+      </ResponsiveContainer>
+    </ChartFigure>
+  );
+}
+
+/* ─────────────────────────────  Pie  ─────────────────────────────── */
+
+export interface PieChartProps
+  extends Pick<
+    BaseChartProps,
+    "title" | "description" | "height" | "loading" | "className" | "valueFormatter"
+  > {
+  data: Array<{ name: string; value: number; color?: string }>;
+}
+
+export function PieChart({
+  data,
+  title,
+  description,
+  height = 300,
+  loading,
+  className,
+  valueFormatter = defaultFormatter,
+}: PieChartProps) {
+  const anim = useAnimation();
+  const total = data.reduce((sum, d) => sum + d.value, 0);
+  const pct = (v: number) => (total ? Math.round((v / total) * 100) : 0);
+  const slices = data.map((d) => `${d.name} ${pct(d.value)}%`).join(", ");
+  const srCaption = `Pie chart "${title}" with ${data.length} slices: ${slices}.`;
+
+  if (loading) return <ChartSkeleton height={height} className={className} />;
+
+  return (
+    <ChartFigure
+      title={title}
+      description={description}
+      className={className}
+      srCaption={srCaption}
+      table={
+        <table className="sr-only">
+          <caption>{title}</caption>
+          <thead>
+            <tr>
+              <th scope="col">Segment</th>
+              <th scope="col">Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((d) => (
+              <tr key={d.name}>
+                <th scope="row">{d.name}</th>
+                <td>{valueFormatter(d.value)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      }
+    >
+      <ResponsiveContainer width="100%" height={height}>
+        <RcPieChart accessibilityLayer>
+          <Tooltip {...tooltipProps} formatter={toRechartsFormatter(valueFormatter)} />
+          <Legend />
+          <Pie
+            data={data}
+            dataKey="value"
+            nameKey="name"
+            cx="50%"
+            cy="50%"
+            outerRadius="80%"
+            {...anim}
+          >
+            {data.map((d, i) => (
+              <Cell key={d.name} fill={d.color ?? CHART_COLORS[i % CHART_COLORS.length]} />
+            ))}
+          </Pie>
+        </RcPieChart>
+      </ResponsiveContainer>
+    </ChartFigure>
+  );
+}

--- a/frontend/src/app/components/global_ui/BottomNav.tsx
+++ b/frontend/src/app/components/global_ui/BottomNav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { LayoutDashboard, HandCoins, PiggyBank, SendHorizontal, User, Clock } from "lucide-react";
+import { LayoutDashboard, HandCoins, PiggyBank, Settings, Clock } from "lucide-react";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { useLocale } from "next-intl";
@@ -16,7 +16,7 @@ const navItems = [
   { name: "Loans", href: "/loans", icon: HandCoins },
   { name: "Lend", href: "/lend", icon: PiggyBank },
   { name: "Activity", href: "/activity", icon: Clock },
-  { name: "Profile", href: "/profile", icon: User },
+  { name: "Settings", href: "/settings", icon: Settings },
 ];
 
 export function BottomNav() {
@@ -31,7 +31,10 @@ export function BottomNav() {
       aria-label="Mobile navigation"
       className="fixed bottom-0 left-0 right-0 z-50 border-t border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950 lg:hidden"
     >
-      <div className="flex items-center justify-around px-2 py-2">
+      <div
+        className="flex items-center justify-around px-2 py-2"
+        style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}
+      >
         {navItems.map((item) => {
           const isActive =
             pathname === `/${locale}${item.href}` ||
@@ -42,7 +45,7 @@ export function BottomNav() {
               key={item.name}
               href={getHref(item.href)}
               className={cn(
-                "flex flex-col items-center justify-center rounded-lg px-3 py-2 text-xs font-medium transition-colors",
+                "flex min-h-[44px] min-w-[44px] flex-col items-center justify-center rounded-lg px-3 py-2 text-xs font-medium transition-colors",
                 isActive
                   ? "text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-950/30"
                   : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200",

--- a/frontend/src/app/components/global_ui/DisconnectWalletDialog.tsx
+++ b/frontend/src/app/components/global_ui/DisconnectWalletDialog.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { LogOut } from "lucide-react";
+import Modal from "../ui/Modal";
+import { Button } from "../ui/Button";
+
+interface DisconnectWalletDialogProps {
+  isOpen: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * Confirmation dialog shown before disconnecting the wallet.
+ *
+ * Pair with `useDisconnectWallet`, which owns the open state and performs the
+ * cache-cancel / store-reset / redirect work when the user confirms.
+ */
+export function DisconnectWalletDialog({
+  isOpen,
+  onCancel,
+  onConfirm,
+}: DisconnectWalletDialogProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onCancel} title="Disconnect wallet?" size="sm">
+      <div className="space-y-4">
+        <div className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+          <LogOut className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" aria-hidden="true" />
+          <p className="text-sm text-zinc-600 dark:text-zinc-300">
+            You&apos;ll be signed out and pending requests cancelled, then returned to the
+            home page. Your funds and on-chain activity are not affected.
+          </p>
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <Button variant="secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={onConfirm}>
+            Disconnect
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/app/components/global_ui/Header.tsx
+++ b/frontend/src/app/components/global_ui/Header.tsx
@@ -24,6 +24,8 @@ import { LanguageSwitcher } from "./LanguageSwitcher";
 import { useTranslations, useLocale } from "next-intl";
 import { useKeyboardShortcuts, createGlobalShortcuts, createNavigationShortcuts, createWalletShortcuts, createSearchShortcut } from "../../hooks/useKeyboardShortcuts";
 import { KeyboardShortcutsHelp } from "../ui/KeyboardShortcutsHelp";
+import { DisconnectWalletDialog } from "./DisconnectWalletDialog";
+import { useDisconnectWallet } from "../../hooks/useDisconnectWallet";
 
 function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -49,6 +51,8 @@ export function Header({ onMenuClick, className }: HeaderProps) {
   const isConnected = useWalletStore((state) => state.status === "connected");
   const walletAddress = useWalletStore((state) => state.address);
   const { connectWallet, disconnectWallet } = useWallet();
+  const { isConfirmOpen, requestDisconnect, cancelDisconnect, confirmDisconnect } =
+    useDisconnectWallet(`/${locale}`);
   const user = useUserStore((state) => state.user);
   const gamificationStore = useGamificationStore();
   const toast = useContractToast();
@@ -240,8 +244,9 @@ export function Header({ onMenuClick, className }: HeaderProps) {
 
   const handleWalletToggle = async () => {
     if (isConnected) {
-      disconnectWallet();
-      toast.info("Wallet disconnected", "Reconnect anytime to continue borrowing and lending.");
+      // Ask for confirmation first; the actual teardown happens in
+      // handleConfirmDisconnect once the user accepts.
+      requestDisconnect();
       return;
     }
 
@@ -255,6 +260,14 @@ export function Header({ onMenuClick, className }: HeaderProps) {
         error instanceof Error ? error.message : "Unable to connect to Freighter.",
       );
     }
+  };
+
+  const handleConfirmDisconnect = async () => {
+    // Tear down the wallet provider session, then clear client state,
+    // cancel in-flight requests and redirect home.
+    disconnectWallet();
+    await confirmDisconnect();
+    toast.info("Wallet disconnected", "Reconnect anytime to continue borrowing and lending.");
   };
 
   const profileLabel = user?.email
@@ -428,13 +441,20 @@ export function Header({ onMenuClick, className }: HeaderProps) {
           </div>
         </button>
       </div>
-    </header>
-    {shortcutsHelpOpen && (
-      <KeyboardShortcutsHelp
-        isOpen={shortcutsHelpOpen}
-        onClose={() => setShortcutsHelpOpen(false)}
-        shortcuts={allShortcuts}
+
+      {shortcutsHelpOpen && (
+        <KeyboardShortcutsHelp
+          isOpen={shortcutsHelpOpen}
+          onClose={() => setShortcutsHelpOpen(false)}
+          shortcuts={allShortcuts}
+        />
+      )}
+
+      <DisconnectWalletDialog
+        isOpen={isConfirmOpen}
+        onCancel={cancelDisconnect}
+        onConfirm={handleConfirmDisconnect}
       />
-    )}
+    </header>
   );
 }

--- a/frontend/src/app/components/ui/CopyButton.tsx
+++ b/frontend/src/app/components/ui/CopyButton.tsx
@@ -1,32 +1,99 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Copy, CheckCheck } from "lucide-react";
+import { cn } from "@/app/utils/cn";
 
 interface CopyButtonProps {
+  /** The string to place on the clipboard. */
   value: string;
+  /** Accessible description of what is being copied, e.g. "wallet address". */
+  label?: string;
+  /** Render the word "Copied!" next to the icon while the feedback is showing. */
+  showLabel?: boolean;
+  className?: string;
 }
 
+/** How long the "Copied!" confirmation stays visible after a successful copy. */
 export const COPY_FEEDBACK_RESET_MS = 2000;
 
-export function CopyButton({ value }: CopyButtonProps) {
-  const [copied, setCopied] = useState(false);
+/**
+ * Copy the given text to the clipboard.
+ *
+ * Uses the async Clipboard API where available (all modern browsers, requires a
+ * secure context) and falls back to a hidden `<textarea>` + `document.execCommand`
+ * for older mobile browsers and non-HTTPS origins.
+ */
+export async function copyToClipboard(value: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(value);
+      return true;
+    } catch {
+      // fall through to the legacy path
+    }
+  }
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(value).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), COPY_FEEDBACK_RESET_MS);
-    });
-  };
+  if (typeof document === "undefined") return false;
+
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.value = value;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.top = "-9999px";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+export function CopyButton({
+  value,
+  label = "to clipboard",
+  showLabel = false,
+  className,
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+
+  const handleCopy = useCallback(async () => {
+    const ok = await copyToClipboard(value);
+    if (!ok) return;
+    setCopied(true);
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_RESET_MS);
+  }, [value]);
+
+  const title = copied ? "Copied!" : `Copy ${label}`;
 
   return (
     <button
+      type="button"
       onClick={handleCopy}
-      className="p-1.5 rounded-md text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 dark:hover:text-zinc-200 dark:hover:bg-zinc-800 transition-colors"
-      title="Copy to clipboard"
-      aria-label={copied ? "Copied to clipboard" : "Copy to clipboard"}
+      className={cn(
+        "inline-flex min-h-[32px] items-center gap-1.5 rounded-md p-1.5 text-zinc-400 transition-colors",
+        "hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500",
+        className,
+      )}
+      title={title}
+      aria-label={copied ? `Copied ${label}` : `Copy ${label}`}
+      aria-live="polite"
     >
-      {copied ? <CheckCheck className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+      {copied ? (
+        <CheckCheck className="h-4 w-4 text-green-500" aria-hidden="true" />
+      ) : (
+        <Copy className="h-4 w-4" aria-hidden="true" />
+      )}
+      {showLabel && <span className="text-xs font-medium">{copied ? "Copied!" : "Copy"}</span>}
     </button>
   );
 }

--- a/frontend/src/app/hooks/useDisconnectWallet.ts
+++ b/frontend/src/app/hooks/useDisconnectWallet.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { useWalletStore } from "../stores/useWalletStore";
+import { useUserStore } from "../stores/useUserStore";
+import { useGamificationStore } from "../stores/useGamificationStore";
+import { useUIStore } from "../stores/useUIStore";
+
+/**
+ * useDisconnectWallet
+ *
+ * Drives the "disconnect wallet" flow so a user never ends up looking at stale,
+ * half-authenticated UI:
+ *
+ *  1. `requestDisconnect()` opens a confirmation dialog (`isConfirmOpen`).
+ *  2. `confirmDisconnect()`:
+ *       - cancels every in-flight query and mutation, then clears the cache so
+ *         no late response repopulates the UI after we've signed out;
+ *       - resets all client stores (wallet, user, gamification, UI) to their
+ *         initial state;
+ *       - redirects to the home page.
+ *  3. `cancelDisconnect()` just closes the dialog.
+ *
+ * Wrap the returned `isConfirmOpen` / `confirmDisconnect` / `cancelDisconnect`
+ * with `<DisconnectWalletDialog />`.
+ */
+export function useDisconnectWallet(redirectTo = "/") {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [isConfirmOpen, setConfirmOpen] = useState(false);
+
+  const disconnectWallet = useWalletStore((s) => s.disconnect);
+  const clearUser = useUserStore((s) => s.clearUser);
+  const resetGamification = useGamificationStore((s) => s.resetGamification);
+  const closeAllModals = useUIStore((s) => s.closeAllModals);
+  const clearToasts = useUIStore((s) => s.clearToasts);
+
+  const requestDisconnect = useCallback(() => setConfirmOpen(true), []);
+  const cancelDisconnect = useCallback(() => setConfirmOpen(false), []);
+
+  const confirmDisconnect = useCallback(async () => {
+    // 1. Stop anything in flight so no stale response lands after sign-out.
+    await queryClient.cancelQueries();
+    queryClient.getMutationCache().clear();
+    queryClient.clear();
+
+    // 2. Reset every client store to a clean, logged-out state.
+    disconnectWallet();
+    clearUser();
+    resetGamification();
+    closeAllModals();
+    clearToasts();
+
+    // 3. Leave the user on a clean home screen.
+    setConfirmOpen(false);
+    router.replace(redirectTo);
+  }, [
+    queryClient,
+    disconnectWallet,
+    clearUser,
+    resetGamification,
+    closeAllModals,
+    clearToasts,
+    router,
+    redirectTo,
+  ]);
+
+  return { isConfirmOpen, requestDisconnect, cancelDisconnect, confirmDisconnect };
+}

--- a/frontend/src/app/hooks/useSwipe.ts
+++ b/frontend/src/app/hooks/useSwipe.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useRef, type TouchEvent } from "react";
+
+export interface SwipeHandlers {
+  onSwipeLeft?: () => void;
+  onSwipeRight?: () => void;
+  onSwipeUp?: () => void;
+  onSwipeDown?: () => void;
+  /** Minimum travel in px before a gesture counts as a swipe. Default 48. */
+  threshold?: number;
+}
+
+interface SwipeBindings {
+  onTouchStart: (e: TouchEvent) => void;
+  onTouchEnd: (e: TouchEvent) => void;
+}
+
+/**
+ * Lightweight touch-swipe detector for carousels, modals and sheets.
+ *
+ * Spread the returned object onto the element you want to make swipeable:
+ *
+ * ```tsx
+ * const swipe = useSwipe({ onSwipeLeft: next, onSwipeRight: prev });
+ * <div {...swipe}>…</div>
+ * ```
+ *
+ * Pointer/mouse dragging is intentionally not handled — this is for touch
+ * devices, where swipe is the expected interaction. Keep keyboard/button
+ * controls for everyone else.
+ */
+export function useSwipe({
+  onSwipeLeft,
+  onSwipeRight,
+  onSwipeUp,
+  onSwipeDown,
+  threshold = 48,
+}: SwipeHandlers): SwipeBindings {
+  const start = useRef<{ x: number; y: number } | null>(null);
+
+  return {
+    onTouchStart: (e: TouchEvent) => {
+      const t = e.touches[0];
+      start.current = { x: t.clientX, y: t.clientY };
+    },
+    onTouchEnd: (e: TouchEvent) => {
+      if (!start.current) return;
+      const t = e.changedTouches[0];
+      const dx = t.clientX - start.current.x;
+      const dy = t.clientY - start.current.y;
+      start.current = null;
+
+      if (Math.abs(dx) > Math.abs(dy)) {
+        if (dx <= -threshold) onSwipeLeft?.();
+        else if (dx >= threshold) onSwipeRight?.();
+      } else {
+        if (dy <= -threshold) onSwipeUp?.();
+        else if (dy >= threshold) onSwipeDown?.();
+      }
+    },
+  };
+}


### PR DESCRIPTION
Resolves four frontend issues. Each change is additive and scoped to its own commit.

## #124 — Accessible chart component library
New reusable library at `src/app/components/charts/primitives` built on the already‑installed Recharts.

- `LineChart`, `AreaChart`, `BarChart` (optional `stacked`) and `PieChart` sharing a `{ data, xKey, series, valueFormatter }` API and a brand‑neutral categorical palette.
- **Screen‑reader friendly:** every chart renders inside a labelled `<figure>`/`<figcaption>`, exposes its underlying data as a visually‑hidden `<table>`, adds a one‑line text summary, and turns on Recharts' `accessibilityLayer` for keyboard navigation of data points. The decorative SVG is `aria-hidden`.
- **Motion:** entry animations are disabled when `prefers-reduced-motion: reduce` is set (via framer‑motion's `useReducedMotion`).
- `ChartSkeleton` loading placeholder for all chart types.

Acceptance: all charts carry ARIA labelling; animations respect `prefers-reduced-motion`.

## #125 — Wallet disconnect confirmation & session cleanup
- `useDisconnectWallet()` — opens a confirmation step, then on confirm **cancels every in‑flight query + mutation and clears the query cache**, **resets all Zustand stores** (wallet, user, gamification, UI modals/toasts) and **redirects to the home page**.
- `DisconnectWalletDialog` — reusable confirmation modal (Cancel / Disconnect) built on the existing `Modal` (focus trap, ESC / backdrop dismiss).
- `Header` wallet button now asks before disconnecting and runs the full teardown on accept. Also wraps the component's previously unterminated JSX `return` (two sibling roots) in a single root element.

Acceptance: no pending requests survive a disconnect; the user lands on a clean home state.

## #126 — Mobile bottom navigation & gestures
- `BottomNav`: every item is now a `>=44px` touch target, respects the iOS safe‑area inset, and matches the issue's item list (Home, Loans, Lend, Activity, Settings).
- `useSwipe()` — a small touch‑only swipe detector (configurable threshold, 4‑direction handlers) for carousels, modals and sheets.

Acceptance: primary actions are one tap away on mobile; no horizontal overflow.

## #128 — Copy‑to‑clipboard with feedback
- `CopyButton` gains an `execCommand` fallback for browsers/contexts without the async Clipboard API (older mobile Safari/Chrome, non‑secure origins).
- Native tooltip + `aria-live` announcement of the "Copied" state; feedback still auto‑resets after 2s (`COPY_FEEDBACK_RESET_MS`).
- Optional `showLabel` prop for a visible "Copy" / "Copied!" label; larger, focus‑visible hit area.
- Exported standalone `copyToClipboard()` helper for non‑button call sites.

Acceptance: one‑click copy for addresses/hashes with visible feedback for 2s.

closes #124
closes #125
closes #126
closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)