### PR TITLE
test: add unit coverage for auditLogService, eventStreamService, LoansPageClient & LoanApplicationWizard

### DIFF
--- a/backend/src/services/__tests__/auditLogService.test.ts
+++ b/backend/src/services/__tests__/auditLogService.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+type QueryResult = { rows: Record<string, unknown>[] };
+const mockQuery = jest.fn<(sql: string, params?: unknown[]) => Promise<QueryResult>>();
+
+jest.unstable_mockModule('../../db/connection.js', () => ({
+  query: mockQuery,
+}));
+
+const { getAuditLogs } = await import('../auditLogService.js');
+
+function rows(count: number, startId = 1) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: startId + i,
+    actor: `actor-${startId + i}`,
+    action: 'loan.approve',
+    created_at: new Date('2026-08-01T00:00:00.000Z'),
+  }));
+}
+
+describe('auditLogService.getAuditLogs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('query construction', () => {
+    it('selects with no WHERE clause when no filters are supplied', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await getAuditLogs({});
+
+      const [sql, values] = mockQuery.mock.calls[0];
+      expect(sql).not.toContain('WHERE');
+      expect(sql).toContain('ORDER BY created_at DESC');
+      // Only the limit placeholder (default 25 + 1) is bound.
+      expect(values).toEqual([26]);
+    });
+
+    it('filters by actor', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await getAuditLogs({ actor: 'GADMIN' });
+
+      const [sql, values] = mockQuery.mock.calls[0];
+      expect(sql).toContain('WHERE actor = $1');
+      expect(values).toEqual(['GADMIN', 26]);
+    });
+
+    it('filters by action', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await getAuditLogs({ action: 'loan.reject' });
+
+      const [sql, values] = mockQuery.mock.calls[0];
+      expect(sql).toContain('WHERE action = $1');
+      expect(values).toEqual(['loan.reject', 26]);
+    });
+
+    it('combines multiple filters with AND and sequential placeholders', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await getAuditLogs({
+        actor: 'GADMIN',
+        action: 'loan.approve',
+        from: '2026-01-01',
+        to: '2026-02-01',
+        cursor: '500',
+      });
+
+      const [sql, values] = mockQuery.mock.calls[0];
+      expect(sql).toContain(
+        'WHERE actor = $1 AND action = $2 AND created_at >= $3 AND created_at <= $4 AND id < $5',
+      );
+      expect(values).toEqual(['GADMIN', 'loan.approve', '2026-01-01', '2026-02-01', '500', 26]);
+    });
+
+    it('honours a custom limit and binds limit + 1 for look-ahead', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await getAuditLogs({ limit: 5 });
+
+      const [sql, values] = mockQuery.mock.calls[0];
+      expect(sql).toContain('LIMIT $1');
+      expect(values).toEqual([6]);
+    });
+  });
+
+  describe('pagination', () => {
+    it('returns no nextCursor when the page is not full', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: rows(3) });
+
+      const result = await getAuditLogs({ limit: 10 });
+
+      expect(result.data).toHaveLength(3);
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('trims the look-ahead row and exposes the last visible id as nextCursor', async () => {
+      // limit 2 → service requests 3, gets 3 back → hasNext.
+      mockQuery.mockResolvedValueOnce({ rows: rows(3) });
+
+      const result = await getAuditLogs({ limit: 2 });
+
+      expect(result.data).toHaveLength(2);
+      expect(result.data.map((r) => (r as { id: number }).id)).toEqual([1, 2]);
+      expect(result.nextCursor).toBe('2');
+    });
+  });
+
+  describe('total count', () => {
+    it('omits the COUNT query unless withTotal is true', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: rows(1) });
+
+      const result = await getAuditLogs({});
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      expect(result.total).toBeUndefined();
+    });
+
+    it('runs a COUNT query and returns the numeric total when withTotal is true', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: rows(1) });
+      mockQuery.mockResolvedValueOnce({ rows: [{ count: '42' }] });
+
+      const result = await getAuditLogs({ withTotal: true });
+
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+      expect(mockQuery.mock.calls[1][0]).toContain('SELECT COUNT(*)');
+      expect(result.total).toBe(42);
+    });
+
+    it('defaults the total to 0 when the COUNT row is missing', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const result = await getAuditLogs({ withTotal: true });
+
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe('PII handling on retrieval', () => {
+    // Redaction of sensitive payload fields happens at write time in
+    // backend/src/middleware/auditLog.ts (covered by src/tests/auditLog.test.ts).
+    // The retrieval path must never re-expand or mutate what was persisted.
+    it('returns persisted (already-redacted) rows verbatim without un-masking', async () => {
+      const stored = {
+        id: 7,
+        actor: 'GADMIN',
+        action: 'auth.login',
+        payload: { email: '[REDACTED]', token: '[REDACTED]', ip: '203.0.113.4' },
+      };
+      mockQuery.mockResolvedValueOnce({ rows: [stored] });
+
+      const result = await getAuditLogs({});
+
+      expect(result.data[0]).toEqual(stored);
+      expect(JSON.stringify(result.data[0])).not.toContain('@');
+    });
+  });
+});

--- a/backend/src/services/__tests__/eventStreamService.test.ts
+++ b/backend/src/services/__tests__/eventStreamService.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+jest.unstable_mockModule('../../utils/logger.js', () => ({
+  default: {
+    withContext: () => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    }),
+  },
+}));
+
+const { eventStreamService } = await import('../eventStreamService.js');
+type LoanEventPayload = Parameters<typeof eventStreamService.broadcast>[0];
+
+interface FakeRes {
+  write: jest.Mock;
+  end: jest.Mock;
+}
+
+function makeRes(): FakeRes {
+  return { write: jest.fn(), end: jest.fn() };
+}
+
+// The service's `Response` type is far wider than what it actually touches
+// (only `.write` / `.end`), so a minimal fake is sufficient.
+function asRes(res: FakeRes) {
+  return res as unknown as Parameters<typeof eventStreamService.sendEvent>[0];
+}
+
+function makeEvent(overrides: Partial<LoanEventPayload> = {}): LoanEventPayload {
+  return {
+    eventId: 'evt-1',
+    eventType: 'LoanFunded',
+    loanId: 1,
+    address: 'GBORROWER',
+    amount: '1000000000',
+    amountDisplay: '100.0000000',
+    ledger: 42,
+    ledgerClosedAt: '2026-08-01T00:00:00Z',
+    txHash: 'abc123',
+    ...overrides,
+  };
+}
+
+describe('eventStreamService', () => {
+  beforeEach(() => {
+    eventStreamService.reset();
+  });
+
+  afterEach(() => {
+    eventStreamService.reset();
+    jest.useRealTimers();
+  });
+
+  describe('connection lifecycle', () => {
+    it('tracks a borrower subscription in the connection counts', () => {
+      const res = makeRes();
+      eventStreamService.subscribeAddress('user-1', 'GBORROWER', asRes(res));
+
+      expect(eventStreamService.getConnectionCount()).toEqual({
+        borrower: 1,
+        admin: 0,
+        total: 1,
+      });
+      expect(eventStreamService.getUserConnectionCount('user-1')).toBe(1);
+    });
+
+    it('tracks an admin subscription separately', () => {
+      const res = makeRes();
+      eventStreamService.subscribeAll('admin-1', asRes(res));
+
+      expect(eventStreamService.getConnectionCount()).toEqual({
+        borrower: 0,
+        admin: 1,
+        total: 1,
+      });
+    });
+
+    it('cleans up all state when the borrower unsubscribe fn is called', () => {
+      const res = makeRes();
+      const unsubscribe = eventStreamService.subscribeAddress('user-1', 'GBORROWER', asRes(res));
+
+      unsubscribe();
+
+      expect(eventStreamService.getConnectionCount().total).toBe(0);
+      expect(eventStreamService.getUserConnectionCount('user-1')).toBe(0);
+      expect(eventStreamService.canOpenConnection('user-1')).toBe(true);
+    });
+
+    it('cleans up admin state when the admin unsubscribe fn is called', () => {
+      const res = makeRes();
+      const unsubscribe = eventStreamService.subscribeAll('admin-1', asRes(res));
+
+      unsubscribe();
+
+      expect(eventStreamService.getConnectionCount().total).toBe(0);
+      expect(eventStreamService.getUserConnectionCount('admin-1')).toBe(0);
+    });
+
+    it('does not leak between users sharing a borrower address', () => {
+      const a = makeRes();
+      const b = makeRes();
+      const unsubA = eventStreamService.subscribeAddress('user-a', 'GSHARED', asRes(a));
+      eventStreamService.subscribeAddress('user-b', 'GSHARED', asRes(b));
+
+      unsubA();
+
+      expect(eventStreamService.getUserConnectionCount('user-a')).toBe(0);
+      expect(eventStreamService.getUserConnectionCount('user-b')).toBe(1);
+      expect(eventStreamService.getConnectionCount().borrower).toBe(1);
+    });
+  });
+
+  describe('per-user connection limiting', () => {
+    it('allows up to the maximum connections per user then refuses more', () => {
+      const max = eventStreamService.getMaxConnectionsPerUser();
+      for (let i = 0; i < max; i += 1) {
+        expect(eventStreamService.canOpenConnection('user-1')).toBe(true);
+        eventStreamService.subscribeAddress('user-1', 'GBORROWER', asRes(makeRes()));
+      }
+
+      expect(eventStreamService.getUserConnectionCount('user-1')).toBe(max);
+      expect(eventStreamService.canOpenConnection('user-1')).toBe(false);
+    });
+
+    it('frees a slot again once a connection unsubscribes', () => {
+      const first = eventStreamService.subscribeAddress('user-1', 'GBORROWER', asRes(makeRes()));
+      eventStreamService.subscribeAddress('user-1', 'GBORROWER', asRes(makeRes()));
+      eventStreamService.subscribeAddress('user-1', 'GBORROWER', asRes(makeRes()));
+      expect(eventStreamService.canOpenConnection('user-1')).toBe(false);
+
+      first();
+
+      expect(eventStreamService.canOpenConnection('user-1')).toBe(true);
+    });
+  });
+
+  describe('broadcast', () => {
+    it('writes a well-formed SSE frame to the matching borrower client', () => {
+      const res = makeRes();
+      eventStreamService.subscribeAddress('user-1', 'GBORROWER', asRes(res));
+
+      eventStreamService.broadcast(makeEvent({ eventId: 'evt-9', address: 'GBORROWER' }));
+
+      expect(res.write).toHaveBeenCalledTimes(1);
+      const frame = res.write.mock.calls[0][0] as string;
+      expect(frame).toContain('id: evt-9\n');
+      expect(frame).toContain('event: loan-event\n');
+      expect(frame).toContain('data: ');
+      expect(frame.endsWith('\n\n')).toBe(true);
+    });
+
+    it('does not deliver to borrower clients subscribed to a different address', () => {
+      const other = makeRes();
+      eventStreamService.subscribeAddress('user-2', 'GOTHER', asRes(other));
+
+      eventStreamService.broadcast(makeEvent({ address: 'GBORROWER' }));
+
+      expect(other.write).not.toHaveBeenCalled();
+    });
+
+    it('fans out to every admin client regardless of address', () => {
+      const admin1 = makeRes();
+      const admin2 = makeRes();
+      eventStreamService.subscribeAll('admin-1', asRes(admin1));
+      eventStreamService.subscribeAll('admin-2', asRes(admin2));
+
+      eventStreamService.broadcast(makeEvent({ address: 'GBORROWER' }));
+
+      expect(admin1.write).toHaveBeenCalledTimes(1);
+      expect(admin2.write).toHaveBeenCalledTimes(1);
+    });
+
+    it('evicts a client whose write throws instead of failing the broadcast', () => {
+      const healthy = makeRes();
+      const broken = makeRes();
+      broken.write.mockImplementation(() => {
+        throw new Error('EPIPE');
+      });
+      eventStreamService.subscribeAddress('user-1', 'GBORROWER', asRes(broken));
+      eventStreamService.subscribeAddress('user-2', 'GBORROWER', asRes(healthy));
+
+      expect(() => eventStreamService.broadcast(makeEvent({ address: 'GBORROWER' }))).not.toThrow();
+
+      expect(healthy.write).toHaveBeenCalledTimes(1);
+      expect(eventStreamService.getConnectionCount().borrower).toBe(1);
+    });
+  });
+
+  describe('PII masking', () => {
+    it('redacts known PII fields before serialising the SSE payload', () => {
+      const res = makeRes();
+      const event = makeEvent({
+        recipient_email: 'alice@example.com',
+        recipient_phone: '+15551234567',
+        recipient_name: 'Alice Borrower',
+        email: 'alice@example.com',
+        phone: '+15551234567',
+        legalName: 'Alice Q. Borrower',
+      } as Partial<LoanEventPayload>);
+
+      eventStreamService.sendEvent(asRes(res), event);
+
+      const frame = res.write.mock.calls[0][0] as string;
+      const data = JSON.parse(frame.split('data: ')[1].trim());
+      for (const field of [
+        'recipient_email',
+        'recipient_phone',
+        'recipient_name',
+        'email',
+        'phone',
+        'legalName',
+      ]) {
+        expect(data[field]).toBe('[REDACTED]');
+      }
+      expect(frame).not.toContain('alice@example.com');
+      expect(frame).not.toContain('Alice Borrower');
+      // Non-PII fields are still present.
+      expect(data.txHash).toBe('abc123');
+      expect(data.amount).toBe('1000000000');
+    });
+  });
+
+  describe('heartbeat', () => {
+    it('pings every connected client on the heartbeat interval', () => {
+      jest.useFakeTimers();
+      const res = makeRes();
+      eventStreamService.subscribeAddress('user-1', 'GBORROWER', asRes(res));
+
+      jest.advanceTimersByTime(30_000);
+
+      expect(res.write).toHaveBeenCalledWith(': ping\n\n');
+    });
+
+    it('stops the heartbeat timer once the last client disconnects', () => {
+      jest.useFakeTimers();
+      const res = makeRes();
+      const unsubscribe = eventStreamService.subscribeAddress('user-1', 'GBORROWER', asRes(res));
+
+      unsubscribe();
+      res.write.mockClear();
+      jest.advanceTimersByTime(60_000);
+
+      expect(res.write).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('closeAllConnections', () => {
+    it('sends a shutdown frame, ends every socket and clears all state', () => {
+      const borrower = makeRes();
+      const admin = makeRes();
+      eventStreamService.subscribeAddress('user-1', 'GBORROWER', asRes(borrower));
+      eventStreamService.subscribeAll('admin-1', asRes(admin));
+
+      eventStreamService.closeAllConnections('maintenance');
+
+      for (const res of [borrower, admin]) {
+        const frame = res.write.mock.calls[0][0] as string;
+        expect(frame).toContain('event: shutdown');
+        expect(frame).toContain('maintenance');
+        expect(res.end).toHaveBeenCalledTimes(1);
+      }
+      expect(eventStreamService.getConnectionCount().total).toBe(0);
+    });
+  });
+});

--- a/frontend/src/app/[locale]/loans/LoansPageClient.test.tsx
+++ b/frontend/src/app/[locale]/loans/LoansPageClient.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LoansPageClient } from "./LoansPageClient";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => "en",
+}));
+
+const useBorrowerLoansPage = jest.fn();
+jest.mock("../../hooks/useApi", () => ({
+  useBorrowerLoansPage: (...args: unknown[]) => useBorrowerLoansPage(...args),
+}));
+
+jest.mock("../../stores/useWalletStore", () => ({
+  useWalletStore: (selector: (state: { address: string | null }) => unknown) =>
+    selector({ address: "GBORROWER" }),
+  selectWalletAddress: (state: { address: string | null }) => state.address,
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const FUTURE = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+
+function loan(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    borrower: "GBORROWERADDRESS1",
+    status: "active",
+    totalOwed: 1000,
+    nextPaymentDeadline: FUTURE,
+    ...overrides,
+  };
+}
+
+function mockLoansPage(state: Record<string, unknown>) {
+  useBorrowerLoansPage.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    ...state,
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("LoansPageClient", () => {
+  it("renders the loading skeleton while the loans query is pending", () => {
+    mockLoansPage({ isLoading: true });
+
+    render(<LoansPageClient />);
+
+    // The skeleton has no filter tabs / heading text.
+    expect(screen.queryByRole("button", { name: "tabs.all" })).not.toBeInTheDocument();
+    expect(screen.queryByText("title")).not.toBeInTheDocument();
+  });
+
+  it("renders an error panel when the loans query fails", () => {
+    mockLoansPage({ isError: true });
+
+    render(<LoansPageClient />);
+
+    expect(screen.getByText(/Failed to load loans/i)).toBeInTheDocument();
+  });
+
+  it("renders a row per loan with status badge and formatted amount", () => {
+    mockLoansPage({
+      data: {
+        items: [
+          loan({ id: 1, borrower: "GBORROWER_ONE", totalOwed: 1000, status: "active" }),
+          loan({ id: 2, borrower: "GBORROWER_TWO", totalOwed: 2500.5, status: "repaid" }),
+        ],
+        pageInfo: { hasNext: false, nextCursor: null },
+      },
+    });
+
+    render(<LoansPageClient />);
+
+    expect(screen.getByText("GBORROWER_ONE")).toBeInTheDocument();
+    expect(screen.getByText("GBORROWER_TWO")).toBeInTheDocument();
+    expect(screen.getByText("$1,000.00")).toBeInTheDocument();
+    expect(screen.getByText("$2,500.50")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Repaid")).toBeInTheDocument();
+  });
+
+  it("shows an overdue loan as defaulted when its next payment deadline has passed", () => {
+    mockLoansPage({
+      data: {
+        items: [
+          loan({
+            id: 3,
+            status: "active",
+            nextPaymentDeadline: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+          }),
+        ],
+        pageInfo: { hasNext: false, nextCursor: null },
+      },
+    });
+
+    render(<LoansPageClient />);
+
+    expect(screen.getByText("Defaulted")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when the borrower has no loans", () => {
+    mockLoansPage({
+      data: { items: [], pageInfo: { hasNext: false, nextCursor: null } },
+    });
+
+    render(<LoansPageClient />);
+
+    expect(screen.getByText("empty.title")).toBeInTheDocument();
+    expect(screen.queryByText("Previous")).not.toBeInTheDocument();
+  });
+
+  it("re-queries with the selected status filter when a tab is clicked", async () => {
+    const user = userEvent.setup();
+    mockLoansPage({
+      data: { items: [loan()], pageInfo: { hasNext: false, nextCursor: null } },
+    });
+
+    render(<LoansPageClient />);
+    expect(useBorrowerLoansPage).toHaveBeenLastCalledWith(
+      "GBORROWER",
+      expect.objectContaining({ status: undefined }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "tabs.active" }));
+
+    expect(useBorrowerLoansPage).toHaveBeenLastCalledWith(
+      "GBORROWER",
+      expect.objectContaining({ status: "active" }),
+    );
+  });
+
+  it("advances the cursor when the next page is requested", async () => {
+    const user = userEvent.setup();
+    mockLoansPage({
+      data: {
+        items: [loan()],
+        pageInfo: { hasNext: true, nextCursor: "cursor-2" },
+      },
+    });
+
+    render(<LoansPageClient />);
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    expect(useBorrowerLoansPage).toHaveBeenLastCalledWith(
+      "GBORROWER",
+      expect.objectContaining({ cursor: "cursor-2" }),
+    );
+  });
+});

--- a/frontend/src/app/components/loan-wizard/__tests__/LoanApplicationWizard.test.tsx
+++ b/frontend/src/app/components/loan-wizard/__tests__/LoanApplicationWizard.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LoanApplicationWizard } from "../LoanApplicationWizard";
+
+// Each real step is a large form with its own dependencies (money policy,
+// signature flow, NFT lookups). The wizard's own responsibility is the step
+// state machine — navigation, clamping, error reset and submission wiring — so
+// the steps are stubbed with buttons that invoke the callbacks the wizard hands
+// them.
+
+jest.mock("../WizardStepper", () => ({
+  WizardStepper: ({ currentStep }: { currentStep: number }) => (
+    <div data-testid="stepper">step-{currentStep}</div>
+  ),
+}));
+
+jest.mock("../StepAmountAsset", () => ({
+  StepAmountAsset: ({
+    onNext,
+    onError,
+    onChange,
+    error,
+  }: {
+    onNext: () => void;
+    onError: (m: string | null) => void;
+    onChange: (u: Record<string, unknown>) => void;
+    error: string | null;
+  }) => (
+    <div>
+      <p>panel: amount</p>
+      {error ? <p role="alert">{error}</p> : null}
+      <button onClick={() => onChange({ amount: "500" })}>amount-set</button>
+      <button onClick={() => onError("Enter a valid loan amount.")}>amount-error</button>
+      <button onClick={onNext}>amount-next</button>
+    </div>
+  ),
+}));
+
+jest.mock("../StepRepaymentSchedule", () => ({
+  StepRepaymentSchedule: ({ onNext, onBack }: { onNext: () => void; onBack: () => void }) => (
+    <div>
+      <p>panel: repayment</p>
+      <button onClick={onBack}>repayment-back</button>
+      <button onClick={onNext}>repayment-next</button>
+    </div>
+  ),
+}));
+
+jest.mock("../StepCollateralNFT", () => ({
+  StepCollateralNFT: ({ onNext, onBack }: { onNext: () => void; onBack: () => void }) => (
+    <div>
+      <p>panel: collateral</p>
+      <button onClick={onBack}>collateral-back</button>
+      <button onClick={onNext}>collateral-next</button>
+    </div>
+  ),
+}));
+
+jest.mock("../StepFinalSignature", () => ({
+  StepFinalSignature: ({
+    onBack,
+    onSuccess,
+    borrowerAddress,
+  }: {
+    onBack: () => void;
+    onSuccess: (loanId: string) => void;
+    borrowerAddress: string;
+  }) => (
+    <div>
+      <p>panel: signature</p>
+      <p>signer: {borrowerAddress}</p>
+      <button onClick={onBack}>signature-back</button>
+      <button onClick={() => onSuccess("loan-123")}>signature-submit</button>
+    </div>
+  ),
+}));
+
+function renderWizard(props: Partial<React.ComponentProps<typeof LoanApplicationWizard>> = {}) {
+  const onSuccess = jest.fn();
+  render(
+    <LoanApplicationWizard
+      borrowerAddress="GBORROWERADDRESS"
+      creditScore={720}
+      maxAmount={5000}
+      onSuccess={onSuccess}
+      {...props}
+    />,
+  );
+  return { onSuccess };
+}
+
+describe("LoanApplicationWizard", () => {
+  it("starts on step 1 (amount & asset)", () => {
+    renderWizard();
+
+    expect(screen.getByText("panel: amount")).toBeInTheDocument();
+    expect(screen.getByTestId("stepper")).toHaveTextContent("step-1");
+  });
+
+  it("walks forward through every step in order", async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    await user.click(screen.getByRole("button", { name: "amount-next" }));
+    expect(screen.getByText("panel: repayment")).toBeInTheDocument();
+    expect(screen.getByTestId("stepper")).toHaveTextContent("step-2");
+
+    await user.click(screen.getByRole("button", { name: "repayment-next" }));
+    expect(screen.getByText("panel: collateral")).toBeInTheDocument();
+    expect(screen.getByTestId("stepper")).toHaveTextContent("step-3");
+
+    await user.click(screen.getByRole("button", { name: "collateral-next" }));
+    expect(screen.getByText("panel: signature")).toBeInTheDocument();
+    expect(screen.getByTestId("stepper")).toHaveTextContent("step-4");
+  });
+
+  it("walks back to a previous step", async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    await user.click(screen.getByRole("button", { name: "amount-next" }));
+    await user.click(screen.getByRole("button", { name: "repayment-next" }));
+    expect(screen.getByText("panel: collateral")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "collateral-back" }));
+    expect(screen.getByText("panel: repayment")).toBeInTheDocument();
+    expect(screen.getByTestId("stepper")).toHaveTextContent("step-2");
+  });
+
+  it("does not go back past the first step", async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    // Step 1 has no back control; the stepper stays on step 1.
+    expect(screen.getByTestId("stepper")).toHaveTextContent("step-1");
+    await user.click(screen.getByRole("button", { name: "amount-set" }));
+    expect(screen.getByTestId("stepper")).toHaveTextContent("step-1");
+  });
+
+  it("does not advance past the final step", async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    await user.click(screen.getByRole("button", { name: "amount-next" }));
+    await user.click(screen.getByRole("button", { name: "repayment-next" }));
+    await user.click(screen.getByRole("button", { name: "collateral-next" }));
+    expect(screen.getByTestId("stepper")).toHaveTextContent("step-4");
+
+    // The final step exposes no "next"; submitting is the only forward action.
+    expect(screen.queryByRole("button", { name: /-next$/ })).not.toBeInTheDocument();
+  });
+
+  it("surfaces a step validation error and clears it on navigation", async () => {
+    const user = userEvent.setup();
+    renderWizard();
+
+    await user.click(screen.getByRole("button", { name: "amount-error" }));
+    expect(screen.getByRole("alert")).toHaveTextContent("Enter a valid loan amount.");
+
+    await user.click(screen.getByRole("button", { name: "amount-next" }));
+    expect(screen.getByText("panel: repayment")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "repayment-back" }));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("passes the borrower address to the signature step and reports the new loan id", async () => {
+    const user = userEvent.setup();
+    const { onSuccess } = renderWizard({ borrowerAddress: "GSIGNER99" });
+
+    await user.click(screen.getByRole("button", { name: "amount-next" }));
+    await user.click(screen.getByRole("button", { name: "repayment-next" }));
+    await user.click(screen.getByRole("button", { name: "collateral-next" }));
+
+    expect(screen.getByText("signer: GSIGNER99")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "signature-submit" }));
+    expect(onSuccess).toHaveBeenCalledWith("loan-123");
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for four core modules that previously had none. Tests only — no production code changes.

| Issue | Module | Area |
| --- | --- | --- |
| #27 | `backend/src/services/auditLogService.ts` | Security audit log retrieval |
| #28 | `backend/src/services/eventStreamService.ts` | SSE connection management |
| #29 | `frontend/.../loans/LoansPageClient.tsx` | Borrower loans page |
| #30 | `frontend/.../loan-wizard/LoanApplicationWizard.tsx` | Loan application flow |

## Backend

### `auditLogService` (#27)
- `WHERE` clause construction for every filter (`actor`, `action`, `from`, `to`, `cursor`) and their `AND`-combined, sequentially numbered placeholders
- keyset pagination: `limit + 1` look-ahead query, trimming the extra row, and `nextCursor` derived from the last visible id
- optional `COUNT(*)` query gated behind `withTotal`, including the `0` default when the count row is absent
- retrieval returns persisted rows verbatim and never un-masks them; payload redaction happens at write time in `middleware/auditLog.ts` (already covered by `src/tests/auditLog.test.ts`), cross-referenced in a test comment

### `eventStreamService` (#28)
- SSE connection lifecycle for borrower and admin streams
- per-user connection limiting (`MAX_CONNECTIONS_PER_USER`), including slot reuse after unsubscribe
- `unsubscribe` cleans up every internal map, with no leak between two users sharing a borrower address
- `broadcast`: SSE frame format (`id:` / `event: loan-event` / `data:`), borrower-vs-admin routing, and eviction of a client whose `write()` throws without failing the broadcast
- PII masking of `recipient_email` / `recipient_phone` / `recipient_name` / `email` / `phone` / `legalName` before serialisation, with non-PII fields left intact
- heartbeat starts on the first client and stops once the last one disconnects (fake timers)
- `closeAllConnections` emits a shutdown frame, ends every socket, and clears all state

## Frontend

### `LoansPageClient` (#29)
- loading skeleton and error-panel states
- one row per loan with the correct status badge and currency-formatted amount
- an `active` loan past its next payment deadline is displayed as `defaulted`
- empty state when the borrower has no loans
- filter tabs trigger a re-query with the selected status
- pagination advances the cursor when **Next** is clicked

Dependencies (`useApi`, `useWalletStore`, `next-intl`) are mocked following the existing pattern in `RemittanceForm.test.tsx` / `settings/page.test.tsx`.

### `LoanApplicationWizard` (#30)
The four step components are stubbed so the tests isolate the wizard's own responsibility — the step state machine:
- starts on step 1
- forward navigation through all four steps, asserting the active panel and stepper position
- backward navigation
- clamping at the first and last steps
- a step validation error is surfaced and cleared on navigation
- `borrowerAddress` is passed through to the signature step and the new loan id is reported via `onSuccess`

## Testing

- Backend: `auditLogService.test.ts` + `eventStreamService.test.ts` — 26 tests passing
- Frontend: `LoansPageClient.test.tsx` (7) + `LoanApplicationWizard.test.tsx` (7) — 14 tests passing

Closes #27
Closes #28
Closes #29
Closes #30
