### PR TITLE
feat(frontend): resolve #31, #32, #33, #35

### DIFF
--- a/frontend/src/app/[locale]/lend/LendPageClient.test.tsx
+++ b/frontend/src/app/[locale]/lend/LendPageClient.test.tsx
@@ -1,0 +1,211 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LendPageClient } from "./LendPageClient";
+import {
+  useDepositorPortfolio,
+  useInvalidatePoolStats,
+  useLoans,
+  usePoolStats,
+  useYieldHistory,
+} from "../../hooks/useApi";
+import { useDepositOperation, useWithdrawalOperation } from "../../hooks/useRepaymentOperation";
+import { useWalletStore } from "../../stores/useWalletStore";
+
+jest.mock("next-intl", () => ({
+  useLocale: () => "en",
+  useTranslations: () => (key: string, values?: Record<string, unknown>) =>
+    values ? `${key}:${JSON.stringify(values)}` : key,
+}));
+
+jest.mock("../../hooks/useApi", () => ({
+  useDepositorPortfolio: jest.fn(),
+  useInvalidatePoolStats: jest.fn(),
+  useLoans: jest.fn(),
+  usePoolStats: jest.fn(),
+  useYieldHistory: jest.fn(),
+}));
+
+jest.mock("../../hooks/useRepaymentOperation", () => ({
+  useDepositOperation: jest.fn(),
+  useWithdrawalOperation: jest.fn(),
+}));
+
+jest.mock("../../hooks/useSSE", () => ({
+  useSSE: () => "connected",
+}));
+
+jest.mock("../../stores/useWalletStore", () => ({
+  useWalletStore: jest.fn(),
+  selectWalletAddress: (state: { address: string | null }) => state.address,
+}));
+
+jest.mock("../../components/charts/YieldEarningsChart", () => ({
+  YieldEarningsChart: ({ data }: { data: unknown[] }) => (
+    <div data-testid="yield-chart">points:{data.length}</div>
+  ),
+}));
+
+jest.mock("../../components/ui/OperationProgress", () => ({
+  OperationProgress: () => null,
+}));
+
+const mockedPoolStats = usePoolStats as jest.Mock;
+const mockedDepositor = useDepositorPortfolio as jest.Mock;
+const mockedLoans = useLoans as jest.Mock;
+const mockedYield = useYieldHistory as jest.Mock;
+const mockedInvalidate = useInvalidatePoolStats as jest.Mock;
+const mockedDepositOp = useDepositOperation as jest.Mock;
+const mockedWithdrawalOp = useWithdrawalOperation as jest.Mock;
+const mockedUseWalletStore = useWalletStore as unknown as jest.Mock;
+
+const ADDRESS = "GDEPOSITOR0000000000";
+const executeDeposit = jest.fn();
+const executeWithdrawal = jest.fn();
+
+function connectWallet(address: string | null) {
+  mockedUseWalletStore.mockImplementation((selector: (s: { address: string | null }) => unknown) =>
+    selector({ address }),
+  );
+}
+
+function setQueries(
+  overrides: {
+    pool?: Record<string, unknown>;
+    depositor?: Record<string, unknown>;
+    loans?: Record<string, unknown>;
+    yieldHistory?: Record<string, unknown>;
+  } = {},
+) {
+  mockedPoolStats.mockReturnValue({
+    data: {
+      totalDeposits: 12000,
+      utilizationRate: 0.5,
+      apy: 0.08,
+      activeLoansCount: 3,
+      withdrawalCooldownLedgers: 0,
+    },
+    isLoading: false,
+    isError: false,
+    ...overrides.pool,
+  });
+  mockedDepositor.mockReturnValue({
+    data: { depositAmount: 5000, sharePercent: 0.25, estimatedYield: 320, lastDepositAt: null },
+    isLoading: false,
+    isError: false,
+    ...overrides.depositor,
+  });
+  mockedLoans.mockReturnValue({
+    data: [],
+    isLoading: false,
+    isError: false,
+    ...overrides.loans,
+  });
+  mockedYield.mockReturnValue({
+    data: [{ date: "2026-01-01", earnings: 100, apy: 0.08, principal: 5000 }],
+    isLoading: false,
+    isError: false,
+    ...overrides.yieldHistory,
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  connectWallet(ADDRESS);
+  mockedInvalidate.mockReturnValue(jest.fn());
+  mockedDepositOp.mockReturnValue({ executeDeposit, isLoading: false, transaction: null });
+  mockedWithdrawalOp.mockReturnValue({ executeWithdrawal, isLoading: false, transaction: null });
+  setQueries();
+});
+
+describe("LendPageClient", () => {
+  it("prompts the visitor to connect a wallet when none is connected", () => {
+    connectWallet(null);
+    render(<LendPageClient />);
+
+    expect(
+      screen.getByText("Connect your wallet to view your lending pool portfolio."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the pool statistics for a connected lender", () => {
+    render(<LendPageClient />);
+
+    expect(screen.getByText("$12,000.00")).toBeInTheDocument();
+    expect(screen.getByText("50.00%")).toBeInTheDocument();
+    expect(screen.getByText("8.00%")).toBeInTheDocument();
+
+    const activeLoansCard = screen.getByText("Active Loans").closest("article");
+    expect(activeLoansCard).not.toBeNull();
+    expect(within(activeLoansCard as HTMLElement).getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders the depositor's position summary", () => {
+    render(<LendPageClient />);
+
+    expect(screen.getByText("$5,000.00")).toBeInTheDocument();
+    expect(screen.getByText("25.00%")).toBeInTheDocument();
+    expect(screen.getByText("$320.00")).toBeInTheDocument();
+  });
+
+  it("submits a deposit with the parsed amount and connected address", async () => {
+    const user = userEvent.setup();
+    render(<LendPageClient />);
+
+    await user.click(screen.getByRole("button", { name: "Deposit" }));
+
+    expect(executeDeposit).toHaveBeenCalledWith({ amount: 100, depositorAddress: ADDRESS });
+  });
+
+  it("submits a withdrawal with the parsed amount and connected address", async () => {
+    const user = userEvent.setup();
+    render(<LendPageClient />);
+
+    await user.click(screen.getByRole("button", { name: "Withdraw" }));
+
+    expect(executeWithdrawal).toHaveBeenCalledWith({ amount: 50, depositorAddress: ADDRESS });
+  });
+
+  it("does not submit a deposit for a non-positive amount", async () => {
+    const user = userEvent.setup();
+    render(<LendPageClient />);
+
+    const input = screen.getByLabelText("Deposit Amount");
+    await user.clear(input);
+    await user.type(input, "0");
+    await user.click(screen.getByRole("button", { name: "Deposit" }));
+
+    expect(executeDeposit).not.toHaveBeenCalled();
+  });
+
+  it("passes mapped yield history to the earnings chart", () => {
+    render(<LendPageClient />);
+
+    expect(screen.getByTestId("yield-chart")).toHaveTextContent("points:1");
+  });
+
+  it("shows the empty state when there is no yield history", () => {
+    setQueries({ yieldHistory: { data: [] } });
+    render(<LendPageClient />);
+
+    expect(screen.queryByTestId("yield-chart")).not.toBeInTheDocument();
+    expect(screen.getByText("No yield history yet")).toBeInTheDocument();
+  });
+
+  it("renders a dashboard-level error when a query fails", () => {
+    setQueries({ pool: { data: undefined, isError: true } });
+    render(<LendPageClient />);
+
+    expect(
+      screen.getByText("Failed to load lender dashboard data. Please try again."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a loading skeleton state while pool data is loading", () => {
+    setQueries({ pool: { data: undefined, isLoading: true } });
+    render(<LendPageClient />);
+
+    // Stat values are replaced by skeletons while loading.
+    expect(screen.queryByText("$12,000.00")).not.toBeInTheDocument();
+    expect(screen.getByText("Total Pool Size")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/[locale]/liquidations/LiquidationsClient.test.tsx
+++ b/frontend/src/app/[locale]/liquidations/LiquidationsClient.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LiquidationsClient from "./LiquidationsClient";
+import {
+  buildLiquidateLoanTransaction,
+  submitLoanTransaction,
+  useLiquidatableLoans,
+  type LiquidatableLoan,
+} from "../../hooks/useApi";
+import { useWallet } from "../../components/providers/WalletProvider";
+import { useContractToast } from "../../hooks/useContractToast";
+import { useWalletStore } from "../../stores/useWalletStore";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+jest.mock("../../hooks/useApi", () => ({
+  queryKeys: { loans: { liquidatable: () => ["loans", "liquidatable"] } },
+  useLiquidatableLoans: jest.fn(),
+  buildLiquidateLoanTransaction: jest.fn(),
+  submitLoanTransaction: jest.fn(),
+}));
+
+jest.mock("../../components/providers/WalletProvider", () => ({
+  useWallet: jest.fn(),
+}));
+
+jest.mock("../../hooks/useContractToast", () => ({
+  useContractToast: jest.fn(),
+}));
+
+const invalidateQueries = jest.fn();
+jest.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries }),
+}));
+
+jest.mock("../../stores/useWalletStore", () => ({
+  useWalletStore: jest.fn(),
+  selectWalletAddress: (state: { address: string | null }) => state.address,
+}));
+
+const mockedUseLiquidatableLoans = useLiquidatableLoans as jest.Mock;
+const mockedUseWallet = useWallet as jest.Mock;
+const mockedUseContractToast = useContractToast as jest.Mock;
+const mockedUseWalletStore = useWalletStore as unknown as jest.Mock;
+const mockedBuild = buildLiquidateLoanTransaction as jest.Mock;
+const mockedSubmit = submitLoanTransaction as jest.Mock;
+
+const LOAN: LiquidatableLoan = {
+  loanId: 12,
+  borrower: "GBORROWER1234567890",
+  collateral: 1500,
+  totalDebt: 1800,
+  healthFactor: 0.85,
+  collateralRatio: 0.9,
+  liquidationThreshold: 1,
+  source: "contract",
+};
+
+const signTransaction = jest.fn();
+const toast = {
+  showPending: jest.fn(() => "toast-id"),
+  showSuccess: jest.fn(),
+  showError: jest.fn(),
+  error: jest.fn(),
+};
+
+function setQuery(overrides: Partial<ReturnType<typeof useLiquidatableLoans>>) {
+  mockedUseLiquidatableLoans.mockReturnValue({
+    data: [],
+    isLoading: false,
+    isError: false,
+    refetch: jest.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useLiquidatableLoans>);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  signTransaction.mockResolvedValue("signed-xdr");
+  mockedBuild.mockResolvedValue({ unsignedTxXdr: "unsigned-xdr" });
+  mockedSubmit.mockResolvedValue({ txHash: "0xabc", status: "SUCCESS" });
+  mockedUseWallet.mockReturnValue({ signTransaction });
+  mockedUseContractToast.mockReturnValue(toast);
+  mockedUseWalletStore.mockImplementation((selector: (s: { address: string | null }) => unknown) =>
+    selector({ address: "GLIQUIDATOR000000000" }),
+  );
+  setQuery({ data: [LOAN] });
+});
+
+describe("LiquidationsClient rendering", () => {
+  it("shows the skeleton while the liquidatable loans query is loading", () => {
+    setQuery({ isLoading: true });
+    render(<LiquidationsClient />);
+
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.queryByText("empty.title")).not.toBeInTheDocument();
+  });
+
+  it("renders the error empty-state when the query fails", () => {
+    setQuery({ isError: true });
+    render(<LiquidationsClient />);
+
+    expect(screen.getByText("error.title")).toBeInTheDocument();
+  });
+
+  it("renders the empty-state when there are no liquidatable loans", () => {
+    setQuery({ data: [] });
+    render(<LiquidationsClient />);
+
+    expect(screen.getByText("empty.title")).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("renders a table row with the loan's financials", () => {
+    render(<LiquidationsClient />);
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByText("#12")).toBeInTheDocument();
+    expect(screen.getByText("GBORROWER1234567890")).toBeInTheDocument();
+    expect(screen.getByText("$1,500.00")).toBeInTheDocument();
+    expect(screen.getByText("$1,800.00")).toBeInTheDocument();
+    expect(screen.getByText("85.00%")).toBeInTheDocument();
+  });
+
+  it("refetches when the refresh control is clicked", async () => {
+    const refetch = jest.fn();
+    setQuery({ data: [LOAN], refetch });
+    const user = userEvent.setup();
+    render(<LiquidationsClient />);
+
+    await user.click(screen.getByRole("button", { name: "refresh" }));
+    expect(refetch).toHaveBeenCalled();
+  });
+});
+
+describe("LiquidationsClient liquidation flow", () => {
+  it("builds, signs and submits a liquidation transaction", async () => {
+    const user = userEvent.setup();
+    render(<LiquidationsClient />);
+
+    await user.click(screen.getByRole("button", { name: "liquidate" }));
+
+    await waitFor(() =>
+      expect(mockedBuild).toHaveBeenCalledWith({
+        loanId: 12,
+        liquidatorPublicKey: "GLIQUIDATOR000000000",
+      }),
+    );
+    expect(signTransaction).toHaveBeenCalledWith("unsigned-xdr");
+    expect(mockedSubmit).toHaveBeenCalledWith("signed-xdr");
+    await waitFor(() =>
+      expect(toast.showSuccess).toHaveBeenCalledWith(
+        "toast-id",
+        expect.objectContaining({ txHash: "0xabc" }),
+      ),
+    );
+    expect(invalidateQueries).toHaveBeenCalled();
+  });
+
+  it("shows an error toast and never builds a transaction without a connected wallet", async () => {
+    mockedUseWalletStore.mockImplementation(
+      (selector: (s: { address: string | null }) => unknown) => selector({ address: null }),
+    );
+    const user = userEvent.setup();
+    render(<LiquidationsClient />);
+
+    await user.click(screen.getByRole("button", { name: "liquidate" }));
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(mockedBuild).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed liquidation through the toast helper", async () => {
+    mockedSubmit.mockRejectedValueOnce(new Error("submit failed"));
+    const user = userEvent.setup();
+    render(<LiquidationsClient />);
+
+    await user.click(screen.getByRole("button", { name: "liquidate" }));
+
+    await waitFor(() =>
+      expect(toast.showError).toHaveBeenCalledWith(
+        "toast-id",
+        expect.objectContaining({ errorMessage: "submit failed" }),
+      ),
+    );
+  });
+});

--- a/frontend/src/app/[locale]/repay/[loanId]/page.tsx
+++ b/frontend/src/app/[locale]/repay/[loanId]/page.tsx
@@ -28,6 +28,10 @@ import {
   formatAmountOnBlur,
   getAssetDecimals,
 } from "../../../utils/amount";
+import {
+  STELLAR_NETWORK_LABEL,
+  STELLAR_NETWORK_PASSPHRASE,
+} from "../../../utils/stellarNetwork";
 
 export default function RepayLoanPage() {
   const params = useParams<{ loanId: string }>();
@@ -111,7 +115,7 @@ export default function RepayLoanPage() {
             },
           ],
           estimatedGasFee: "0.01",
-          network: "Stellar Testnet",
+          network: STELLAR_NETWORK_LABEL,
           contractAddress: contractId,
         },
         async () => {
@@ -135,7 +139,7 @@ export default function RepayLoanPage() {
       setTrackerMessage("Approve the repayment transaction in your wallet.");
 
       const signResult = await signTransaction(unsignedXdr, {
-        networkPassphrase: "Test SDF Network ; September 2015",
+        networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
       });
       if (signResult.error) {
         throw new Error(

--- a/frontend/src/app/[locale]/settings/page.test.tsx
+++ b/frontend/src/app/[locale]/settings/page.test.tsx
@@ -38,9 +38,17 @@ jest.mock("../../stores/useThemeStore", () => ({
   })),
 }));
 
+const mockUpdateProfileMutate = jest.fn();
+const mockToast = jest.fn();
+
 jest.mock("../../hooks/useApi", () => ({
   useNotificationPreferences: () => ({ data: undefined, isLoading: false, error: null }),
   useUpdateNotificationPreferences: () => ({ mutate: jest.fn(), isPending: false }),
+  useUpdateUserProfile: () => ({ mutate: mockUpdateProfileMutate, isPending: false }),
+}));
+
+jest.mock("../../hooks/useToast", () => ({
+  useToast: () => ({ toast: mockToast }),
 }));
 
 jest.mock("../../components/gamification/GamificationSettings", () => ({
@@ -78,5 +86,73 @@ describe("SettingsPage section navigation", () => {
     const panel = screen.getByRole("tabpanel");
     expect(panel).toHaveAttribute("id", panelId);
     expect(panel).toHaveAttribute("aria-labelledby", "settings-tab-profile");
+  });
+});
+
+describe("SettingsPage profile save", () => {
+  beforeEach(() => {
+    mockUpdateProfileMutate.mockReset();
+    mockToast.mockReset();
+  });
+
+  it("persists profile edits through the update-profile mutation", async () => {
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+
+    const displayName = screen.getByLabelText(/display name/i);
+    await user.clear(displayName);
+    await user.type(displayName, "Alice");
+
+    const email = screen.getByLabelText(/email/i);
+    await user.clear(email);
+    await user.type(email, "alice@example.com");
+
+    await user.click(screen.getByRole("button", { name: /save profile/i }));
+
+    expect(mockUpdateProfileMutate).toHaveBeenCalledWith(
+      { id: "Alice", email: "alice@example.com" },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+  });
+
+  it("shows a success toast and confirmation after a successful save", async () => {
+    mockUpdateProfileMutate.mockImplementation((_payload, { onSuccess }) => onSuccess());
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+
+    await user.click(screen.getByRole("button", { name: /save profile/i }));
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "success", title: "Profile saved" }),
+    );
+    expect(await screen.findByRole("button", { name: /saved!/i })).toBeInTheDocument();
+  });
+
+  it("surfaces an error toast and inline message when the save fails", async () => {
+    mockUpdateProfileMutate.mockImplementation((_payload, { onError }) =>
+      onError(new Error("Network unavailable")),
+    );
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+
+    await user.click(screen.getByRole("button", { name: /save profile/i }));
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "destructive", description: "Network unavailable" }),
+    );
+    expect(screen.getByText("Network unavailable")).toBeInTheDocument();
+  });
+
+  it("blocks saving when the display name is empty", async () => {
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+
+    const displayName = screen.getByLabelText(/display name/i);
+    await user.clear(displayName);
+
+    await user.click(screen.getByRole("button", { name: /save profile/i }));
+
+    expect(mockUpdateProfileMutate).not.toHaveBeenCalled();
+    expect(screen.getByText("Display name is required.")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/[locale]/settings/page.tsx
+++ b/frontend/src/app/[locale]/settings/page.tsx
@@ -26,7 +26,12 @@ import {
 } from "../../stores/useWalletStore";
 import { useUserStore, selectUser } from "../../stores/useUserStore";
 import { logoutUser } from "../../lib/session";
-import { useNotificationPreferences, useUpdateNotificationPreferences } from "../../hooks/useApi";
+import {
+  useNotificationPreferences,
+  useUpdateNotificationPreferences,
+  useUpdateUserProfile,
+} from "../../hooks/useApi";
+import { useToast } from "../../hooks/useToast";
 import { COPY_FEEDBACK_RESET_MS } from "../../components/ui";
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -134,11 +139,42 @@ function ProfileSection() {
   const [displayName, setDisplayName] = useState(user?.id ?? "");
   const [email, setEmail] = useState(user?.email ?? "");
   const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const { toast } = useToast();
+  const updateProfile = useUpdateUserProfile();
 
   const handleSave = () => {
-    // In real impl: call PATCH /api/user/profile
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+    const name = displayName.trim();
+
+    if (!name) {
+      setSaveError("Display name is required.");
+      return;
+    }
+
+    setSaveError(null);
+
+    updateProfile.mutate(
+      { id: name, email: email.trim() },
+      {
+        onSuccess: () => {
+          setSaved(true);
+          setTimeout(() => setSaved(false), 2000);
+          toast({
+            variant: "success",
+            title: "Profile saved",
+            description: "Your profile changes have been saved.",
+          });
+        },
+        onError: (error) => {
+          setSaveError(error.message);
+          toast({
+            variant: "destructive",
+            title: "Could not save profile",
+            description: error.message,
+          });
+        },
+      },
+    );
   };
 
   return (
@@ -183,8 +219,15 @@ function ProfileSection() {
           <span className="text-red-600">*</span> Required field
         </p>
 
-        <Button variant="primary" onClick={handleSave} className="w-full sm:w-auto">
-          {saved ? "Saved!" : "Save Profile"}
+        {saveError && <p className="text-sm text-red-600 dark:text-red-400">{saveError}</p>}
+
+        <Button
+          variant="primary"
+          onClick={handleSave}
+          disabled={updateProfile.isPending}
+          className="w-full sm:w-auto"
+        >
+          {updateProfile.isPending ? "Saving..." : saved ? "Saved!" : "Save Profile"}
         </Button>
       </CardContent>
     </Card>

--- a/frontend/src/app/hooks/useApi.ts
+++ b/frontend/src/app/hooks/useApi.ts
@@ -990,6 +990,32 @@ export function useUserProfile(
   });
 }
 
+export interface UpdateUserProfilePayload {
+  /** Public display name. */
+  id?: string;
+  /** Contact email used for notifications. */
+  email?: string;
+}
+
+/**
+ * Persists profile changes via `PATCH /api/user/profile` and refreshes any
+ * cached profile data on success.
+ */
+export function useUpdateUserProfile() {
+  const queryClient = useQueryClient();
+  return useMutation<UserProfile, Error, UpdateUserProfilePayload>({
+    mutationFn: (payload) =>
+      apiFetch<UserProfile>("/user/profile", {
+        method: "PATCH",
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKeys.user.profile(), data);
+      queryClient.invalidateQueries({ queryKey: queryKeys.user.profile() });
+    },
+  });
+}
+
 /**
  * Fetches the current user's wallet balance.
  */

--- a/frontend/src/app/utils/soroban.ts
+++ b/frontend/src/app/utils/soroban.ts
@@ -9,8 +9,10 @@ import {
   xdr,
 } from "@stellar/stellar-sdk";
 
-const DEFAULT_RPC_URL = "https://soroban-testnet.stellar.org";
-const DEFAULT_NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+import { DEFAULT_TESTNET_PASSPHRASE, DEFAULT_TESTNET_RPC_URL } from "./stellarNetwork";
+
+const DEFAULT_RPC_URL = DEFAULT_TESTNET_RPC_URL;
+const DEFAULT_NETWORK_PASSPHRASE = DEFAULT_TESTNET_PASSPHRASE;
 
 interface BuildLoanRequestXdrParams {
   borrower: string;

--- a/frontend/src/app/utils/stellarNetwork.ts
+++ b/frontend/src/app/utils/stellarNetwork.ts
@@ -1,0 +1,32 @@
+/**
+ * utils/stellarNetwork.ts
+ *
+ * Single source of truth for Stellar / Soroban network configuration.
+ *
+ * Network passphrases, RPC URLs and human-readable labels must never be
+ * hardcoded in feature code. Import from here so the app can target testnet,
+ * futurenet or mainnet purely through environment configuration:
+ *
+ *   NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE
+ *   NEXT_PUBLIC_STELLAR_RPC_URL
+ *   NEXT_PUBLIC_STELLAR_NETWORK_LABEL
+ *
+ * The defaults below only exist so local development against the public
+ * Stellar testnet works with zero configuration.
+ */
+
+export const DEFAULT_TESTNET_PASSPHRASE = "Test SDF Network ; September 2015";
+export const DEFAULT_TESTNET_RPC_URL = "https://soroban-testnet.stellar.org";
+export const DEFAULT_NETWORK_LABEL = "Stellar Testnet";
+
+/** Network passphrase used when signing/submitting transactions. */
+export const STELLAR_NETWORK_PASSPHRASE =
+  process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ?? DEFAULT_TESTNET_PASSPHRASE;
+
+/** Soroban RPC endpoint. */
+export const STELLAR_RPC_URL =
+  process.env.NEXT_PUBLIC_STELLAR_RPC_URL ?? DEFAULT_TESTNET_RPC_URL;
+
+/** Human-readable network name for display in transaction previews. */
+export const STELLAR_NETWORK_LABEL =
+  process.env.NEXT_PUBLIC_STELLAR_NETWORK_LABEL ?? DEFAULT_NETWORK_LABEL;


### PR DESCRIPTION
## Summary

Resolves four frontend issues:

| Issue | Area | Change |
|-------|------|--------|
| #31 | Testing | Component tests for `LendPageClient` |
| #32 | Testing | Component tests for `LiquidationsClient` |
| #33 | Bug | Settings profile save now hits the real API instead of a mock |
| #35 | Security / config | Repay page no longer hardcodes the testnet network passphrase |

---

### closes #31  — Tests for `LendPageClient`

New `frontend/src/app/[locale]/lend/LendPageClient.test.tsx` covering:

- **Wallet gating** — the connect-wallet prompt renders when no wallet is connected.
- **Pool stats display** — total pool size, utilization rate, APY and active-loan count render from `usePoolStats`.
- **Depositor position** — deposited amount, pool share and estimated earnings render from `useDepositorPortfolio`.
- **Deposit / withdraw UI flows** — submitting each form calls `executeDeposit` / `executeWithdrawal` with the parsed amount and connected address; a non-positive amount is rejected without calling the operation.
- **Yield display** — mapped yield history is handed to `YieldEarningsChart`, and the empty state renders when there is no history.
- **Loading & error states** — dashboard-level error surface and per-card skeletons.

### closes #32 — Tests for `LiquidationsClient`

New `frontend/src/app/[locale]/liquidations/LiquidationsClient.test.tsx` covering:

- **List rendering** — a row per liquidatable loan with borrower, collateral, debt and health factor formatting.
- **State rendering** — loading skeleton, error empty-state, and no-loans empty-state.
- **Refresh** — the refresh control triggers a refetch.
- **Liquidation action flow** — the liquidate button builds, signs and submits the transaction, reports success via the toast helper and invalidates the liquidatable-loans query.
- **Guard rails** — no transaction is built when the wallet is disconnected; a failed submit is reported through the toast helper.

> Note: the issue mentions "filter by status" and "approve/reject" buttons. The current component exposes a single **Liquidate** action per row and no status filter, so the tests cover the behaviour that actually exists (action flow + empty/error/loading states). Happy to extend if a filter/approval UI is added.

### closes #33  — Settings profile save

- Added `useUpdateUserProfile` in `hooks/useApi.ts` — a mutation that calls `PATCH /user/profile` and refreshes the cached profile on success.
- `ProfileSection` in `settings/page.tsx` now:
  - calls the mutation instead of faking a save,
  - disables the button and shows **Saving…** while the request is in flight,
  - shows a success toast + **Saved!** confirmation on success,
  - shows an error toast and an inline message on failure,
  - validates that the display name is non-empty before submitting.
- Extended `settings/page.test.tsx` with cases for the success path, the error path and the empty-name guard.

### closes #35 — Hardcoded testnet passphrase on the repay page

- New `utils/stellarNetwork.ts` centralises Stellar network config, reading `NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE`, `NEXT_PUBLIC_STELLAR_RPC_URL` and `NEXT_PUBLIC_STELLAR_NETWORK_LABEL` from the environment (testnet defaults only for zero-config local dev, matching the existing pattern in `utils/soroban.ts`).
- `repay/[loanId]/page.tsx` now imports `STELLAR_NETWORK_PASSPHRASE` / `STELLAR_NETWORK_LABEL` instead of the inline `"Test SDF Network ; September 2015"` string and the hardcoded `"Stellar Testnet"` label.
- `utils/soroban.ts` re-uses the shared default constants so there is a single source of truth.

---
