### PR TITLE
Fix wildcard CORS origin validation

### DIFF
--- a/backend/src/__tests__/cors.test.ts
+++ b/backend/src/__tests__/cors.test.ts
@@ -94,4 +94,30 @@ describe('CORS middleware', () => {
     expect(response.status).toBe(200);
     expect(response.headers['access-control-allow-origin']).toBe('http://127.0.0.1:3000');
   });
+
+  it('allows wildcard origins when configured in production', async () => {
+    process.env.CORS_ALLOWED_ORIGINS = 'https://*.example.com';
+
+    const { default: app } = await loadApp();
+
+    const response = await request(app)
+      .get('/health')
+      .set('Origin', 'https://app.example.com');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['access-control-allow-origin']).toBe('https://app.example.com');
+  });
+
+  it('rejects subdomains that do not match wildcard config in production', async () => {
+    process.env.CORS_ALLOWED_ORIGINS = 'https://*.example.com';
+
+    const { default: app } = await loadApp();
+
+    const response = await request(app)
+      .get('/health')
+      .set('Origin', 'https://example.com');
+
+    expect(response.status).toBe(403);
+    expect(response.body.error?.message).toBe('Origin is not allowed by CORS policy');
+  });
 });

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -60,7 +60,34 @@ if (isProduction && allowedOriginsList.length === 0) {
   throw new Error('No allowed origins configured for CORS in production. Set FRONTEND_URL.');
 }
 
-const allowedOrigins = new Set(allowedOriginsList);
+const normalizeOrigin = (value: string) => value.trim().replace(/\/+$/, '').toLowerCase();
+
+const originMatchesPattern = (origin: string, pattern: string): boolean => {
+  const normalizedOrigin = normalizeOrigin(origin);
+  const normalizedPattern = normalizeOrigin(pattern);
+
+  if (!normalizedPattern || normalizedPattern === '*') {
+    return normalizedPattern === '*';
+  }
+
+  if (!normalizedPattern.includes('*')) {
+    return normalizedOrigin === normalizedPattern;
+  }
+
+  const escapedPattern = normalizedPattern
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*');
+
+  return new RegExp(`^${escapedPattern}$`, 'i').test(normalizedOrigin);
+};
+
+const isOriginAllowed = (origin: string): boolean => {
+  if (allowedOriginsList.some((pattern) => originMatchesPattern(origin, pattern))) {
+    return true;
+  }
+
+  return !isProduction && devOrigins.has(origin);
+};
 
 // In non-production environments, additionally allow common localhost origins
 // used during development. Without this, staging/preview deployments that run
@@ -93,11 +120,7 @@ const corsOptions: cors.CorsOptions = {
       return callback(null, true);
     }
 
-    if (allowedOrigins.has(origin)) {
-      return callback(null, true);
-    }
-
-    if (!isProduction && devOrigins.has(origin)) {
+    if (isOriginAllowed(origin)) {
       return callback(null, true);
     }
 


### PR DESCRIPTION
## Summary

- Add wildcard-aware origin matching for configured CORS allowlists while preserving exact-match and localhost dev behavior.
- Keep production validation strict while allowing common localhost origins only in non-production.

Closes #26
Closes #53
Closes #63
Closes #64
